### PR TITLE
Various fixes for moving to a new project and add vanilla Rocky 8 ARM64 image

### DIFF
--- a/daisy/rocky/8/kickstart/rocky_linux_8_arm64.cfg
+++ b/daisy/rocky/8/kickstart/rocky_linux_8_arm64.cfg
@@ -1,0 +1,223 @@
+# rocky-linux-8-options.cfg
+
+### Anaconda installer configuration.
+# Install in text mode.
+text --non-interactive
+url --url="https://download.rockylinux.org/pub/rocky/8/BaseOS/aarch64/os"
+repo --name=AppStream --baseurl="https://download.rockylinux.org/pub/rocky/8/AppStream/aarch64/os"
+repo --name=PowerTools --baseurl="https://download.rockylinux.org/pub/rocky/8/PowerTools/aarch64/os"
+poweroff
+
+# Network configuration
+network --bootproto=dhcp --device=link
+
+### Installed system configuration.
+firewall --enabled
+services --enabled=sshd,rngd --disabled=sshd-keygen@
+skipx
+timezone --utc UTC --ntpservers=metadata.google.internal
+rootpw --iscrypted --lock *
+firstboot --disabled
+user --name=gce --lock
+
+### Disk configuration.
+# Disk configuration is done by including a separate file with disk configuration, otherwise anaconda will try to validate that the disk exists before we configure udev rules.
+%pre --interpreter=/usr/bin/bash
+cp /run/install/isodir/65-gce-disk-naming.rules /etc/udev/rules.d/
+cp /run/install/isodir/google_nvme_id /usr/lib/udev/
+chmod +x /usr/lib/udev/google_nvme_id
+# Wait for coldplug events from boot to settle, or we won't generate new events for the reload/trigger
+udevadm settle
+udevadm control --reload
+udevadm trigger --settle
+tee -a /tmp/disk-config << EOM
+# build_installer.py will replace with the id of the install disk to avoid race conditions
+bootloader --boot-drive=/dev/disk/by-id/google-el-install-disk --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
+# EFI partitioning, creates a GPT partitioned disk.
+clearpart --drives=/dev/disk/by-id/google-el-install-disk --all
+part /boot/efi --size=200 --fstype=efi --ondrive=/dev/disk/by-id/google-el-install-disk
+part / --size=100 --grow --ondrive=/dev/disk/by-id/google-el-install-disk --label=root --fstype=xfs
+EOM
+%end
+%include /tmp/disk-config
+
+# packages.cfg
+# Contains a list of packages to be installed, or not, on all flavors.
+# The %package command begins the package selection section of kickstart.
+# Packages can be specified by group, or package name. @Base and @Core are
+# always selected by default so they do not need to be specified.
+
+%packages
+acpid
+dhcp-client
+dnf-automatic
+net-tools
+openssh-server
+python3
+python38
+rng-tools
+tar
+vim
+-subscription-manager
+-alsa-utils
+-b43-fwcutter
+-dmraid
+-eject
+-gpm
+-irqbalance
+-microcode_ctl
+-smartmontools
+-aic94xx-firmware
+-atmel-firmware
+-b43-openfwwf
+-bfa-firmware
+-ipw2100-firmware
+-ipw2200-firmware
+-ivtv-firmware
+-iwl100-firmware
+-iwl1000-firmware
+-iwl3945-firmware
+-iwl4965-firmware
+-iwl5000-firmware
+-iwl5150-firmware
+-iwl6000-firmware
+-iwl6000g2a-firmware
+-iwl6050-firmware
+-kernel-firmware
+-libertas-usb8388-firmware
+-ql2100-firmware
+-ql2200-firmware
+-ql23xx-firmware
+-ql2400-firmware
+-ql2500-firmware
+-rt61pci-firmware
+-rt73usb-firmware
+-xorg-x11-drv-ati-firmware
+-zd1211-firmware
+%end
+
+%post
+dnf mark remove python38 || exit 1
+tee -a /etc/yum.repos.d/google-cloud.repo << EOM
+[google-compute-engine]
+name=Google Compute Engine
+baseurl=https://packages.cloud.google.com/yum/repos/google-compute-engine-el8-aarch64-stable
+enabled=1
+gpgcheck=1
+repo_gpgcheck=0
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
+       https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+EOM
+tee -a /etc/yum.repos.d/google-cloud.repo << EOM
+[google-cloud-sdk]
+name=Google Cloud SDK
+baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el8-aarch64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=0
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
+       https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+EOM
+%end
+# Google Compute Engine kickstart config for Enterprise Linux 8.
+%onerror
+echo "Build Failed!" > /dev/ttyAMA0
+shutdown -h now
+%end
+
+%post --erroronfail
+set -x
+exec &> /dev/ttyAMA0
+# Delete the dummy user account.
+userdel -r gce
+
+# Import all RPM GPG keys.
+curl -o /etc/pki/rpm-gpg/google-rpm-package-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+curl -o /etc/pki/rpm-gpg/google-key.gpg https://packages.cloud.google.com/yum/doc/yum-key.gpg
+rpm --import /etc/pki/rpm-gpg/*
+
+# Configure the network for GCE.
+# Given that GCE users typically control the firewall at the network API level,
+# we want to leave the standard Linux firewall setup enabled but all-open.
+firewall-offline-cmd --set-default-zone=trusted
+
+cat >>/etc/dhcp/dhclient.conf <<EOL
+# Set the dhclient retry interval to 10 seconds instead of 5 minutes.
+retry 10;
+EOL
+
+# Set google-compute-engine config for EL8.
+cat >>/etc/default/instance_configs.cfg.distro << EOL
+# Disable boto plugin setup.
+[InstanceSetup]
+set_boto_config = false
+EOL
+
+# Install GCE guest packages.
+dnf install -y google-compute-engine google-osconfig-agent gce-disk-expand
+rpm -q google-compute-engine google-osconfig-agent gce-disk-expand || { echo "Build Failed!" > /dev/ttyAMA0; exit 1; }
+
+# Install the Cloud SDK package.
+dnf install -y google-cloud-cli
+
+# Send /root/anaconda-ks.cfg to our logs.
+cp /run/install/ks.cfg /tmp/anaconda-ks.cfg
+
+# Remove files which shouldn't make it into the image. Its possible these files
+# will not exist.
+rm -f /etc/boto.cfg /etc/udev/rules.d/70-persistent-net.rules
+
+# Remove ens4 config from installer.
+rm -f /etc/sysconfig/network-scripts/ifcfg-ens4
+
+# Disable password authentication by default.
+sed -i -e '/^PasswordAuthentication /s/ yes$/ no/' /etc/ssh/sshd_config
+
+# Set ServerAliveInterval and ClientAliveInterval to prevent SSH
+# disconnections. The pattern match is tuned to each source config file.
+# The $'...' quoting syntax tells the shell to expand escape characters.
+sed -i -e $'/^\tServerAliveInterval/d' /etc/ssh/ssh_config
+sed -i -e $'/^Host \\*$/a \\\tServerAliveInterval 420' /etc/ssh/ssh_config
+sed -i -e '/ClientAliveInterval/s/^.*/ClientAliveInterval 420/' /etc/ssh/sshd_config
+
+# Disable root login via SSH by default.
+sed -i -e '/PermitRootLogin yes/s/^.*/PermitRootLogin no/' /etc/ssh/sshd_config
+
+# Update all packages.
+dnf -y update
+
+# Make changes to dnf automatic.conf
+# Apply updates for security (RHEL) by default. NOTE this will not work in CentOS.
+sed -i 's/upgrade_type =.*/upgrade_type = security/' /etc/dnf/automatic.conf
+sed -i 's/apply_updates =.*/apply_updates = yes/' /etc/dnf/automatic.conf
+# Enable the DNF automatic timer service.
+systemctl enable dnf-automatic.timer
+
+# Cleanup this repo- we don't want to continue updating with it.
+# Depending which repos are used in build, one or more of these files will not
+# exist.
+rm -f /etc/yum.repos.d/google-cloud-unstable.repo \
+  /etc/yum.repos.d/google-cloud-staging.repo
+
+# Clean up the cache for smaller images.
+dnf clean all
+rm -fr /var/cache/dnf/*
+
+# Blacklist the floppy module.
+echo "blacklist floppy" > /etc/modprobe.d/blacklist-floppy.conf
+restorecon /etc/modprobe.d/blacklist-floppy.conf
+
+# Generate initramfs from latest kernel instead of the running kernel.
+kver="$(ls -t /lib/modules | head -n1)"
+dracut -f --kver="${kver}"
+
+# Fix selinux contexts on /etc/resolv.conf.
+restorecon /etc/resolv.conf
+%end
+
+# Cleanup.
+%post --nochroot --log=/dev/ttyAMA0
+set -x
+rm -Rf /mnt/sysimage/tmp/*
+%end
+

--- a/daisy/rocky/8/kickstart/rocky_linux_8_optimized_gcp_arm64.cfg
+++ b/daisy/rocky/8/kickstart/rocky_linux_8_optimized_gcp_arm64.cfg
@@ -55,7 +55,6 @@ dnf-automatic
 net-tools
 openssh-server
 python3
-python38
 rng-tools
 tar
 vim
@@ -98,7 +97,6 @@ vim
 %end
 
 %post
-dnf mark remove python38 || exit 1
 tee -a /etc/yum.repos.d/google-cloud.repo << EOM
 [google-compute-engine]
 name=Google Compute Engine

--- a/daisy/rocky/8/rocky_linux_8_arm64.wf.json
+++ b/daisy/rocky/8/rocky_linux_8_arm64.wf.json
@@ -1,0 +1,56 @@
+{
+  "Name": "build-rocky-linux-8-arm64",
+  "Vars": {
+    "google_cloud_repo": {
+      "Value": "stable",
+      "Description": "The Google Cloud Repo branch to use."
+    },
+    "installer_iso": {
+      "Required": true,
+      "Description": "The Rocky Linux 8 installer ISO to build from."
+    },
+    "build_date": {
+      "Value": "${TIMESTAMP}",
+      "Description": "Build datestamp used to version the image."
+    },
+    "publish_project": {
+      "Value": "${PROJECT}",
+      "Description": "A project to publish the resulting image to."
+    }
+  },
+  "Steps": {
+    "build-rocky": {
+      "Timeout": "60m",
+      "IncludeWorkflow": {
+        "Path": "./enterprise_linux.wf.json",
+        "Vars": {
+          "el_release": "rocky-linux-8-arm64",
+          "kickstart_config": "./kickstart/rocky_linux_8_arm64.cfg",
+          "installer_iso": "${installer_iso}",
+          "machine_type": "t2a-standard-4",
+          "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64"
+        }
+      }
+    },
+    "create-image": {
+      "CreateImages": [
+        {
+          "Name": "rocky-linux-8-arm64-v${build_date}",
+          "SourceDisk": "el-install-disk",
+          "Licenses": [
+            "projects/rocky-linux-cloud/global/licenses/rocky-linux-8"
+          ],
+          "Description": "Rocky Linux, Rocky Linux, 8, aarch64 built on ${build_date}",
+          "Family": "rocky-linux-8-arm64",
+          "Project": "${publish_project}",
+          "NoCleanup": true,
+          "ExactName": true,
+          "GuestOsFeatures": ["UEFI_COMPATIBLE"]
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "create-image": ["build-rocky"]
+  }
+}

--- a/daisy/rocky/8/rocky_linux_8_arm64.wf.json
+++ b/daisy/rocky/8/rocky_linux_8_arm64.wf.json
@@ -27,7 +27,7 @@
           "el_release": "rocky-linux-8-arm64",
           "kickstart_config": "./kickstart/rocky_linux_8_arm64.cfg",
           "installer_iso": "${installer_iso}",
-          "machine_type": "t2a-standard-4",
+          "machine_type": "c4a-standard-4",
           "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64"
         }
       }

--- a/daisy/rocky/8/rocky_linux_8_optimized_gcp.wf.json
+++ b/daisy/rocky/8/rocky_linux_8_optimized_gcp.wf.json
@@ -1,5 +1,5 @@
 {
-  "Name": "build-rocky-linux-8-gcp",
+  "Name": "build-rocky-linux-8-optimized-gcp",
   "Vars": {
     "installer_iso": {
       "Required": true,

--- a/daisy/rocky/8/rocky_linux_8_optimized_gcp_arm64.wf.json
+++ b/daisy/rocky/8/rocky_linux_8_optimized_gcp_arm64.wf.json
@@ -23,7 +23,7 @@
           "el_release": "rocky-linux-8-optimized-gcp-arm64",
           "kickstart_config": "./kickstart/rocky_linux_8_optimized_gcp_arm64.cfg",
           "installer_iso": "${installer_iso}",
-          "machine_type": "t2a-standard-4",
+          "machine_type": "c4a-standard-4",
           "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64"
         }
       }

--- a/daisy/rocky/8/rocky_linux_8_optimized_gcp_arm64.wf.json
+++ b/daisy/rocky/8/rocky_linux_8_optimized_gcp_arm64.wf.json
@@ -1,5 +1,5 @@
 {
-  "Name": "build-rocky-linux-8-gcp-arm64",
+  "Name": "build-rocky-linux-8-optimized-gcp-arm64",
   "Vars": {
     "installer_iso": {
       "Required": true,

--- a/daisy/rocky/9/rocky_linux_9_arm64.wf.json
+++ b/daisy/rocky/9/rocky_linux_9_arm64.wf.json
@@ -28,7 +28,7 @@
           "kickstart_config": "./kickstart/rocky_linux_9_arm64.cfg",
           "google_cloud_repo": "${google_cloud_repo}",
           "installer_iso": "${installer_iso}",
-          "machine_type": "t2a-standard-4",
+          "machine_type": "c4a-standard-4",
           "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64"
         }
       }

--- a/daisy/rocky/9/rocky_linux_9_optimized_gcp.wf.json
+++ b/daisy/rocky/9/rocky_linux_9_optimized_gcp.wf.json
@@ -1,5 +1,5 @@
 {
-  "Name": "build-rocky-linux-9-gcp",
+  "Name": "build-rocky-linux-9-optimized-gcp",
   "Vars": {
     "installer_iso": {
       "Required": true,

--- a/daisy/rocky/9/rocky_linux_9_optimized_gcp_arm64.wf.json
+++ b/daisy/rocky/9/rocky_linux_9_optimized_gcp_arm64.wf.json
@@ -1,5 +1,5 @@
 {
-  "Name": "build-rocky-linux-9-gcp-arm64",
+  "Name": "build-rocky-linux-9-optimized-gcp-arm64",
   "Vars": {
     "installer_iso": {
       "Required": true,

--- a/daisy/rocky/9/rocky_linux_9_optimized_gcp_arm64.wf.json
+++ b/daisy/rocky/9/rocky_linux_9_optimized_gcp_arm64.wf.json
@@ -23,7 +23,7 @@
           "el_release": "rocky-linux-9-optimized-gcp-arm64",
           "kickstart_config": "./kickstart/rocky_linux_9_optimized_gcp_arm64.cfg",
           "installer_iso": "${installer_iso}",
-          "machine_type": "t2a-standard-4",
+          "machine_type": "c4a-standard-4",
           "worker_image": "projects/compute-image-tools/global/images/family/debian-12-worker-arm64"
         }
       }

--- a/publish/rocky/8/rocky_linux_8.publish.json
+++ b/publish/rocky/8/rocky_linux_8.publish.json
@@ -1,18 +1,18 @@
 {{/*
   Template to publish UEFI-enabled Rocky Linux images.
-  By default this template is setup to publish to the 'gce-image-builder'
+  By default this template is setup to publish to the 'ciq-build-images'
   project, the 'environment' variable can be used to publish to 'test', 'prod'
   DeleteAfter is set to 180 days for all environments other than prod where no
   time period is set.
 */}}
 {
   "Name": "rocky-linux-8",
-  {{$work_project := printf "%q" "gce-image-builder" -}}
+  {{$work_project := printf "%q" "ciq-build-images" -}}
   {{$endpoint := `"https://www.googleapis.com/compute/alpha/projects/"` -}}
   {{$delete_after := `"24h*30*2"` -}}
   {{if eq .environment "test" -}}
   "WorkProject": {{$work_project}},
-  "PublishProject": "bct-prod-images",
+  "PublishProject": "gce-ciq-images",
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- else if eq .environment "prod" -}}

--- a/publish/rocky/8/rocky_linux_8.wf.json
+++ b/publish/rocky/8/rocky_linux_8.wf.json
@@ -17,7 +17,7 @@
       "Description": "Root of github workflows, defaults to /workflows in the container."
     },
     "gcs_url": {
-      "Required": true,
+      "Value": "gs://gce-ciq-images-prod-artifacts/${NAME}-v${TIMESTAMP}.tar.gz",
       "Description": "The GCS path that image raw file exported to."
     },
     "sbom_destination": {
@@ -25,7 +25,7 @@
       "Description": "SBOM final export destination, copies in place by default"
     },
     "installer_iso": {
-      "Required": true,
+      "Value": "gs://gce-ciq-images-base-isos/Rocky-8-x86_64-boot.iso",
       "Description": "The Rocky Linux 8 installer ISO to build from."
     },
     "sbom_util_gcs_root": {

--- a/publish/rocky/8/rocky_linux_8.wf.json
+++ b/publish/rocky/8/rocky_linux_8.wf.json
@@ -1,8 +1,8 @@
 {
   "Name": "rocky-linux-8",
-  "Project": "gce-image-builder",
+  "Project": "gce-ciq-images",
   "Zone": "us-central1-b",
-  "GCSPath": "gs://gce-image-build-bucket/daisy/${USERNAME}",
+  "GCSPath": "gs://gce-ciq-images-build-bucket/daisy/${USERNAME}",
   "Vars": {
     "build_date": {
       "Value": "${TIMESTAMP}",
@@ -41,7 +41,7 @@
     "build": {
       "TimeOut": "60m",
       "IncludeWorkflow": {
-        "Path": "${workflow_root}/image_build/enterprise_linux/rocky_linux_8.wf.json",
+        "Path": "${workflow_root}/rocky/8/rocky_linux_8.wf.json",
         "Vars": {
           "build_date": "${build_date}",
           "google_cloud_repo": "${google_cloud_repo}",

--- a/publish/rocky/8/rocky_linux_8_arm64.publish.json
+++ b/publish/rocky/8/rocky_linux_8_arm64.publish.json
@@ -1,0 +1,50 @@
+{{/*
+  Template to publish UEFI-enabled Rocky Linux images.
+  By default this template is setup to publish to the 'ciq-build-images'
+  project, the 'environment' variable can be used to publish to 'test', 'prod'
+  DeleteAfter is set to 180 days for all environments other than prod where no
+  time period is set.
+*/}}
+{
+  "Name": "rocky-linux-8-arm64",
+  {{$work_project := printf "%q" "ciq-build-images" -}}
+  {{$endpoint := `"https://www.googleapis.com/compute/alpha/projects/"` -}}
+  {{$delete_after := `"24h*30*2"` -}}
+  {{if eq .environment "test" -}}
+  "WorkProject": {{$work_project}},
+  "PublishProject": "gce-ciq-images",
+  "ComputeEndpoint": {{$endpoint}},
+  "DeleteAfter": {{$delete_after}},
+  {{- else if eq .environment "prod" -}}
+  "WorkProject": {{$work_project}},
+  "PublishProject": "rocky-linux-cloud",
+  "ComputeEndpoint": {{$endpoint}},
+  {{- else if eq .environment "autopush" -}}
+  "WorkProject": {{$work_project}},
+  "PublishProject": "artifact-releaser-autopush",
+  "ComputeEndpoint": {{$endpoint}},
+  "DeleteAfter": "3h",
+  {{- else -}}
+  "WorkProject": {{$work_project}},
+  "PublishProject": {{$work_project}},
+  "ComputeEndpoint": {{$endpoint}},
+  "DeleteAfter": {{$delete_after}},
+  {{- end}}
+  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC"]` -}}
+  {{$time := trimPrefix .publish_version "v"}}
+  "Images": [
+    {
+      "Family": "rocky-linux-8-arm64",
+      "Prefix": "rocky-linux-8-arm64",
+      "Description": "Rocky Linux, Rocky Linux, 8, aarch64 built on {{$time}}",
+      "Architecture": "ARM64",
+      "Licenses": [
+        "projects/rocky-linux-cloud/global/licenses/rocky-linux-8"
+      ],
+      "Labels": {
+        "public-image": "true"
+      },
+      "GuestOsFeatures": {{$guest_features}}
+    }
+  ]
+}

--- a/publish/rocky/8/rocky_linux_8_arm64.wf.json
+++ b/publish/rocky/8/rocky_linux_8_arm64.wf.json
@@ -1,0 +1,75 @@
+{
+  "Name": "rocky-linux-8-arm64",
+  "Project": "gce-ciq-images",
+  "Zone": "us-central1-b",
+  "GCSPath": "gs://gce-ciq-images-build-bucket/daisy/${USERNAME}",
+  "Vars": {
+    "build_date": {
+      "Value": "${TIMESTAMP}",
+      "Description": "Build datestamp used to version the image."
+    },
+    "google_cloud_repo": {
+      "Value": "stable",
+      "Description": "The Google Cloud Repo branch to use."
+    },
+    "workflow_root": {
+      "Value": "/workflows",
+      "Description": "Root of github workflows, defaults to /workflows in the container."
+    },
+    "gcs_url": {
+      "Value": "gs://gce-ciq-images-prod-artifacts/${NAME}-v${TIMESTAMP}.tar.gz",
+      "Description": "The GCS path that image raw file exported to."
+    },
+    "sbom_destination": {
+      "Value": "${OUTSPATH}/export-image.sbom.json",
+      "Description": "SBOM final export destination, copies in place by default"
+    },
+    "installer_iso": {
+      "Value": "gs://gce-ciq-images-base-isos/Rocky-8-aarch64-boot.iso",
+      "Description": "The Rocky Linux 8 installer ISO to build from."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "${OUTSPATH}/export-image-shasum.txt",
+       "Description": "The file where the sha256 sum is stored."
+    }
+  },
+  "Steps": {
+    "build": {
+      "TimeOut": "60m",
+      "IncludeWorkflow": {
+        "Path": "${workflow_root}/rocky/8/rocky_linux_8_arm64.wf.json",
+        "Vars": {
+          "build_date": "${build_date}",
+          "google_cloud_repo": "${google_cloud_repo}",
+          "installer_iso": "${installer_iso}"
+        }
+      }
+    },
+    "export-image": {
+      "Timeout": "60m",
+      "IncludeWorkflow": {
+        "Path": "${workflow_root}/export/disk_export.wf.json",
+        "Vars": {
+          "destination": "${gcs_url}",
+          "sbom_destination": "${sbom_destination}",
+          "source_disk": "el-install-disk",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
+        }
+      }
+    },
+    "cleanup-image": {
+      "DeleteResources": {
+        "Images": ["rocky-linux-8-arm64-v${build_date}"]
+      }
+    }
+  },
+  "Dependencies": {
+    "export-image": ["build"],
+    "cleanup-image": ["export-image"]
+  }
+}

--- a/publish/rocky/8/rocky_linux_8_optimized_gcp.publish.json
+++ b/publish/rocky/8/rocky_linux_8_optimized_gcp.publish.json
@@ -1,18 +1,18 @@
 {{/*
   Template to publish UEFI-enabled Rocky Linux images.
-  By default this template is setup to publish to the 'gce-image-builder'
+  By default this template is setup to publish to the 'ciq-build-images'
   project, the 'environment' variable can be used to publish to 'test', 'prod'
   DeleteAfter is set to 180 days for all environments other than prod where no
   time period is set.
 */}}
 {
   "Name": "rocky-linux-8-optimized-gcp",
-  {{$work_project := printf "%q" "gce-image-builder" -}}
+  {{$work_project := printf "%q" "ciq-build-images" -}}
   {{$endpoint := `"https://www.googleapis.com/compute/alpha/projects/"` -}}
   {{$delete_after := `"24h*30*2"` -}}
   {{if eq .environment "test" -}}
   "WorkProject": {{$work_project}},
-  "PublishProject": "bct-prod-images",
+  "PublishProject": "gce-ciq-images",
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- else if eq .environment "prod" -}}

--- a/publish/rocky/8/rocky_linux_8_optimized_gcp.wf.json
+++ b/publish/rocky/8/rocky_linux_8_optimized_gcp.wf.json
@@ -17,7 +17,7 @@
       "Description": "Root of github workflows, defaults to /workflows in the container."
     },
     "gcs_url": {
-      "Required": true,
+      "Value": "gs://gce-ciq-images-prod-artifacts/${NAME}-v${TIMESTAMP}.tar.gz",
       "Description": "The GCS path that image raw file exported to."
     },
     "sbom_destination": {
@@ -25,7 +25,7 @@
       "Description": "SBOM final export destination, copies in place by default"
     },
     "installer_iso": {
-      "Required": true,
+      "Value": "gs://gce-ciq-images-base-isos/Rocky-8-x86_64-boot.iso",
       "Description": "The Rocky Linux 8 installer ISO to build from."
     },
     "sbom_util_gcs_root": {

--- a/publish/rocky/8/rocky_linux_8_optimized_gcp.wf.json
+++ b/publish/rocky/8/rocky_linux_8_optimized_gcp.wf.json
@@ -1,8 +1,8 @@
 {
   "Name": "rocky-linux-8-optimized-gcp",
-  "Project": "gce-image-builder",
+  "Project": "gce-ciq-images",
   "Zone": "us-central1-b",
-  "GCSPath": "gs://gce-image-build-bucket/daisy/${USERNAME}",
+  "GCSPath": "gs://gce-ciq-images-build-bucket/daisy/${USERNAME}",
   "Vars": {
     "build_date": {
       "Value": "${TIMESTAMP}",
@@ -41,7 +41,7 @@
     "build": {
       "TimeOut": "60m",
       "IncludeWorkflow": {
-        "Path": "${workflow_root}/image_build/enterprise_linux/rocky_linux_8_optimized_gcp.wf.json",
+        "Path": "${workflow_root}/rocky/8/rocky_linux_8_optimized_gcp.wf.json",
         "Vars": {
           "build_date": "${build_date}",
           "installer_iso": "${installer_iso}"

--- a/publish/rocky/8/rocky_linux_8_optimized_gcp_arm64.publish.json
+++ b/publish/rocky/8/rocky_linux_8_optimized_gcp_arm64.publish.json
@@ -1,18 +1,18 @@
 {{/*
   Template to publish UEFI-enabled Rocky Linux images.
-  By default this template is setup to publish to the 'gce-image-builder'
+  By default this template is setup to publish to the 'ciq-build-images'
   project, the 'environment' variable can be used to publish to 'test', 'prod'
   DeleteAfter is set to 180 days for all environments other than prod where no
   time period is set.
 */}}
 {
   "Name": "rocky-linux-8-optimized-gcp-arm64",
-  {{$work_project := printf "%q" "gce-image-builder" -}}
+  {{$work_project := printf "%q" "ciq-build-images" -}}
   {{$endpoint := `"https://www.googleapis.com/compute/alpha/projects/"` -}}
   {{$delete_after := `"24h*30*2"` -}}
   {{if eq .environment "test" -}}
   "WorkProject": {{$work_project}},
-  "PublishProject": "bct-prod-images",
+  "PublishProject": "gce-ciq-images",
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- else if eq .environment "prod" -}}

--- a/publish/rocky/8/rocky_linux_8_optimized_gcp_arm64.wf.json
+++ b/publish/rocky/8/rocky_linux_8_optimized_gcp_arm64.wf.json
@@ -17,7 +17,7 @@
       "Description": "Root of github workflows, defaults to /workflows in the container."
     },
     "gcs_url": {
-      "Required": true,
+      "Value": "gs://gce-ciq-images-prod-artifacts/${NAME}-v${TIMESTAMP}.tar.gz",
       "Description": "The GCS path that image raw file exported to."
     },
     "sbom_destination": {
@@ -25,7 +25,7 @@
       "Description": "SBOM final export destination, copies in place by default"
     },
     "installer_iso": {
-      "Required": true,
+      "Value": "gs://gce-ciq-images-base-isos/Rocky-8-aarch64-boot.iso",
       "Description": "The Rocky Linux 8 installer ISO to build from."
     },
     "sbom_util_gcs_root": {

--- a/publish/rocky/8/rocky_linux_8_optimized_gcp_arm64.wf.json
+++ b/publish/rocky/8/rocky_linux_8_optimized_gcp_arm64.wf.json
@@ -1,8 +1,8 @@
 {
   "Name": "rocky-linux-8-optimized-gcp-arm64",
-  "Project": "gce-image-builder",
+  "Project": "gce-ciq-images",
   "Zone": "us-central1-b",
-  "GCSPath": "gs://gce-image-build-bucket/daisy/${USERNAME}",
+  "GCSPath": "gs://gce-ciq-images-build-bucket/daisy/${USERNAME}",
   "Vars": {
     "build_date": {
       "Value": "${TIMESTAMP}",
@@ -41,7 +41,7 @@
     "build": {
       "TimeOut": "60m",
       "IncludeWorkflow": {
-        "Path": "${workflow_root}/image_build/enterprise_linux/rocky_linux_8_optimized_gcp_arm64.wf.json",
+        "Path": "${workflow_root}/rocky/8/rocky_linux_8_optimized_gcp_arm64.wf.json",
         "Vars": {
           "build_date": "${build_date}",
           "installer_iso": "${installer_iso}"

--- a/publish/rocky/8/rocky_linux_8_optimized_gcp_nvidia_550.publish.json
+++ b/publish/rocky/8/rocky_linux_8_optimized_gcp_nvidia_550.publish.json
@@ -1,18 +1,18 @@
 {{/*
   Template to publish Rocky 8 optimized for GCP/Nvidia images.
-  By default this template is setup to publish to the 'gce-image-builder'
+  By default this template is setup to publish to the 'ciq-build-images'
   project, the 'environment' variable can be used to publish to 'test', 'prod'
   DeleteAfter is set to 180 days for all environments other than prod where no
   time period is set.
 */}}
 {
   "Name": "rocky-linux-8-optimized-gcp-nvidia-550",
-  {{$work_project := printf "%q" "gce-image-builder" -}}
+  {{$work_project := printf "%q" "ciq-build-images" -}}
   {{$endpoint := `"https://www.googleapis.com/compute/alpha/projects/"` -}}
   {{$delete_after := `"24h*30*2"` -}}
   {{if eq .environment "test" -}}
   "WorkProject": {{$work_project}},
-  "PublishProject": "bct-prod-images",
+  "PublishProject": "gce-ciq-images",
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- else if eq .environment "prod" -}}

--- a/publish/rocky/8/rocky_linux_8_optimized_gcp_nvidia_550.wf.json
+++ b/publish/rocky/8/rocky_linux_8_optimized_gcp_nvidia_550.wf.json
@@ -17,7 +17,7 @@
       "Description": "Root of github workflows, defaults to /workflows in the container."
     },
     "gcs_url": {
-      "Required": true,
+      "Value": "gs://gce-ciq-images-prod-artifacts/${NAME}-v${TIMESTAMP}.tar.gz",
       "Description": "The GCS path that image raw file exported to."
     },
     "sbom_destination": {
@@ -25,7 +25,7 @@
       "Description": "SBOM final export destination, copies in place by default"
     },
     "installer_iso": {
-      "Required": true,
+      "Value": "gs://gce-ciq-images-base-isos/Rocky-8-x86_64-boot.iso",
       "Description": "The Rocky Linux 8 installer ISO to build from."
     },
     "sbom_util_gcs_root": {

--- a/publish/rocky/8/rocky_linux_8_optimized_gcp_nvidia_550.wf.json
+++ b/publish/rocky/8/rocky_linux_8_optimized_gcp_nvidia_550.wf.json
@@ -1,8 +1,8 @@
 {
   "Name": "rocky-linux-8-optimized-gcp-nvidia-550",
-  "Project": "gce-image-builder",
+  "Project": "gce-ciq-images",
   "Zone": "us-central1-b",
-  "GCSPath": "gs://gce-image-build-bucket/daisy/${USERNAME}",
+  "GCSPath": "gs://gce-ciq-images-build-bucket/daisy/${USERNAME}",
   "Vars": {
     "build_date": {
       "Value": "${TIMESTAMP}",
@@ -41,7 +41,7 @@
     "build": {
       "TimeOut": "60m",
       "IncludeWorkflow": {
-        "Path": "${workflow_root}/image_build/enterprise_linux/rocky_linux_8_optimized_gcp_nvidia_550.wf.json",
+        "Path": "${workflow_root}/rocky/8/rocky_linux_8_optimized_gcp_nvidia_550.wf.json",
         "Vars": {
           "build_date": "${build_date}",
           "installer_iso": "${installer_iso}"

--- a/publish/rocky/8/rocky_linux_8_optimized_gcp_nvidia_570.publish.json
+++ b/publish/rocky/8/rocky_linux_8_optimized_gcp_nvidia_570.publish.json
@@ -1,18 +1,18 @@
 {{/*
   Template to publish Rocky 8 optimized for GCP/Nvidia images.
-  By default this template is setup to publish to the 'gce-image-builder'
+  By default this template is setup to publish to the 'ciq-build-images'
   project, the 'environment' variable can be used to publish to 'test', 'prod'
   DeleteAfter is set to 180 days for all environments other than prod where no
   time period is set.
 */}}
 {
   "Name": "rocky-linux-8-optimized-gcp-nvidia-570",
-  {{$work_project := printf "%q" "gce-image-builder" -}}
+  {{$work_project := printf "%q" "ciq-build-images" -}}
   {{$endpoint := `"https://www.googleapis.com/compute/alpha/projects/"` -}}
   {{$delete_after := `"24h*30*2"` -}}
   {{if eq .environment "test" -}}
   "WorkProject": {{$work_project}},
-  "PublishProject": "bct-prod-images",
+  "PublishProject": "gce-ciq-images",
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- else if eq .environment "prod" -}}

--- a/publish/rocky/8/rocky_linux_8_optimized_gcp_nvidia_570.wf.json
+++ b/publish/rocky/8/rocky_linux_8_optimized_gcp_nvidia_570.wf.json
@@ -17,7 +17,7 @@
       "Description": "Root of github workflows, defaults to /workflows in the container."
     },
     "gcs_url": {
-      "Required": true,
+      "Value": "gs://gce-ciq-images-prod-artifacts/${NAME}-v${TIMESTAMP}.tar.gz",
       "Description": "The GCS path that image raw file exported to."
     },
     "sbom_destination": {
@@ -25,7 +25,7 @@
       "Description": "SBOM final export destination, copies in place by default"
     },
     "installer_iso": {
-      "Required": true,
+      "Value": "gs://gce-ciq-images-base-isos/Rocky-8-x86_64-boot.iso",
       "Description": "The Rocky Linux 8 installer ISO to build from."
     },
     "sbom_util_gcs_root": {

--- a/publish/rocky/8/rocky_linux_8_optimized_gcp_nvidia_570.wf.json
+++ b/publish/rocky/8/rocky_linux_8_optimized_gcp_nvidia_570.wf.json
@@ -1,8 +1,8 @@
 {
   "Name": "rocky-linux-8-optimized-gcp-nvidia-570",
-  "Project": "gce-image-builder",
+  "Project": "gce-ciq-images",
   "Zone": "us-central1-b",
-  "GCSPath": "gs://gce-image-build-bucket/daisy/${USERNAME}",
+  "GCSPath": "gs://gce-ciq-images-build-bucket/daisy/${USERNAME}",
   "Vars": {
     "build_date": {
       "Value": "${TIMESTAMP}",
@@ -41,7 +41,7 @@
     "build": {
       "TimeOut": "60m",
       "IncludeWorkflow": {
-        "Path": "${workflow_root}/image_build/enterprise_linux/rocky_linux_8_optimized_gcp_nvidia_570.wf.json",
+        "Path": "${workflow_root}/rocky/8/rocky_linux_8_optimized_gcp_nvidia_570.wf.json",
         "Vars": {
           "build_date": "${build_date}",
           "installer_iso": "${installer_iso}"

--- a/publish/rocky/8/rocky_linux_8_optimized_gcp_nvidia_latest.publish.json
+++ b/publish/rocky/8/rocky_linux_8_optimized_gcp_nvidia_latest.publish.json
@@ -1,18 +1,18 @@
 {{/*
   Template to publish Rocky 8 optimized for GCP/Nvidia images.
-  By default this template is setup to publish to the 'gce-image-builder'
+  By default this template is setup to publish to the 'ciq-build-images'
   project, the 'environment' variable can be used to publish to 'test', 'prod'
   DeleteAfter is set to 180 days for all environments other than prod where no
   time period is set.
 */}}
 {
   "Name": "rocky-linux-8-optimized-gcp-nvidia-latest",
-  {{$work_project := printf "%q" "gce-image-builder" -}}
+  {{$work_project := printf "%q" "ciq-build-images" -}}
   {{$endpoint := `"https://www.googleapis.com/compute/alpha/projects/"` -}}
   {{$delete_after := `"24h*30*2"` -}}
   {{if eq .environment "test" -}}
   "WorkProject": {{$work_project}},
-  "PublishProject": "bct-prod-images",
+  "PublishProject": "gce-ciq-images",
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- else if eq .environment "prod" -}}

--- a/publish/rocky/8/rocky_linux_8_optimized_gcp_nvidia_latest.wf.json
+++ b/publish/rocky/8/rocky_linux_8_optimized_gcp_nvidia_latest.wf.json
@@ -1,8 +1,8 @@
 {
   "Name": "rocky-linux-8-optimized-gcp-nvidia-latest",
-  "Project": "gce-image-builder",
+  "Project": "gce-ciq-images",
   "Zone": "us-central1-b",
-  "GCSPath": "gs://gce-image-build-bucket/daisy/${USERNAME}",
+  "GCSPath": "gs://gce-ciq-images-build-bucket/daisy/${USERNAME}",
   "Vars": {
     "build_date": {
       "Value": "${TIMESTAMP}",
@@ -41,7 +41,7 @@
     "build": {
       "TimeOut": "60m",
       "IncludeWorkflow": {
-        "Path": "${workflow_root}/image_build/enterprise_linux/rocky_linux_8_optimized_gcp_nvidia_latest.wf.json",
+        "Path": "${workflow_root}/rocky/8/rocky_linux_8_optimized_gcp_nvidia_latest.wf.json",
         "Vars": {
           "build_date": "${build_date}",
           "installer_iso": "${installer_iso}"

--- a/publish/rocky/8/rocky_linux_8_optimized_gcp_nvidia_latest.wf.json
+++ b/publish/rocky/8/rocky_linux_8_optimized_gcp_nvidia_latest.wf.json
@@ -17,7 +17,7 @@
       "Description": "Root of github workflows, defaults to /workflows in the container."
     },
     "gcs_url": {
-      "Required": true,
+      "Value": "gs://gce-ciq-images-prod-artifacts/${NAME}-v${TIMESTAMP}.tar.gz",
       "Description": "The GCS path that image raw file exported to."
     },
     "sbom_destination": {
@@ -25,7 +25,7 @@
       "Description": "SBOM final export destination, copies in place by default"
     },
     "installer_iso": {
-      "Required": true,
+      "Value": "gs://gce-ciq-images-base-isos/Rocky-8-x86_64-boot.iso",
       "Description": "The Rocky Linux 8 installer ISO to build from."
     },
     "sbom_util_gcs_root": {

--- a/publish/rocky/9/rocky_linux_9.publish.json
+++ b/publish/rocky/9/rocky_linux_9.publish.json
@@ -1,18 +1,18 @@
 {{/*
   Template to publish UEFI-enabled Rocky Linux images.
-  By default this template is setup to publish to the 'gce-image-builder'
+  By default this template is setup to publish to the 'ciq-build-images'
   project, the 'environment' variable can be used to publish to 'test', 'prod'
   DeleteAfter is set to 180 days for all environments other than prod where no
   time period is set.
 */}}
 {
   "Name": "rocky-linux-9",
-  {{$work_project := printf "%q" "gce-image-builder" -}}
+  {{$work_project := printf "%q" "ciq-build-images" -}}
   {{$endpoint := `"https://www.googleapis.com/compute/alpha/projects/"` -}}
   {{$delete_after := `"24h*30*2"` -}}
   {{if eq .environment "test" -}}
   "WorkProject": {{$work_project}},
-  "PublishProject": "bct-prod-images",
+  "PublishProject": "gce-ciq-images",
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- else if eq .environment "prod" -}}

--- a/publish/rocky/9/rocky_linux_9.wf.json
+++ b/publish/rocky/9/rocky_linux_9.wf.json
@@ -17,7 +17,7 @@
       "Description": "Root of github workflows, defaults to /workflows in the container."
     },
     "gcs_url": {
-      "Required": true,
+      "Value": "gs://gce-ciq-images-prod-artifacts/${NAME}-v${TIMESTAMP}.tar.gz",
       "Description": "The GCS path that image raw file exported to."
     },
     "sbom_destination": {
@@ -25,7 +25,7 @@
       "Description": "SBOM final export destination, copies in place by default"
     },
     "installer_iso": {
-      "Required": true,
+      "Value": "gs://gce-ciq-images-base-isos/Rocky-9-x86_64-boot.iso",
       "Description": "The Rocky Linux 9 installer ISO to build from."
     },
     "sbom_util_gcs_root": {

--- a/publish/rocky/9/rocky_linux_9.wf.json
+++ b/publish/rocky/9/rocky_linux_9.wf.json
@@ -1,8 +1,8 @@
 {
   "Name": "rocky-linux-9",
-  "Project": "gce-image-builder",
+  "Project": "gce-ciq-images",
   "Zone": "us-central1-b",
-  "GCSPath": "gs://gce-image-build-bucket/daisy/${USERNAME}",
+  "GCSPath": "gs://gce-ciq-images-build-bucket/daisy/${USERNAME}",
   "Vars": {
     "build_date": {
       "Value": "${TIMESTAMP}",
@@ -41,7 +41,7 @@
     "build": {
       "TimeOut": "60m",
       "IncludeWorkflow": {
-        "Path": "${workflow_root}/image_build/enterprise_linux/rocky_linux_9.wf.json",
+        "Path": "${workflow_root}/rocky/9/rocky_linux_9.wf.json",
         "Vars": {
           "build_date": "${build_date}",
           "google_cloud_repo": "${google_cloud_repo}",

--- a/publish/rocky/9/rocky_linux_9.wf.json
+++ b/publish/rocky/9/rocky_linux_9.wf.json
@@ -1,7 +1,7 @@
 {
   "Name": "rocky-linux-9",
   "Project": "gce-ciq-images",
-  "Zone": "us-central1-b",
+  "Zone": "europe-west4-a",
   "GCSPath": "gs://gce-ciq-images-build-bucket/daisy/${USERNAME}",
   "Vars": {
     "build_date": {

--- a/publish/rocky/9/rocky_linux_9_arm64.publish.json
+++ b/publish/rocky/9/rocky_linux_9_arm64.publish.json
@@ -1,18 +1,18 @@
 {{/*
   Template to publish UEFI-enabled Rocky Linux images.
-  By default this template is setup to publish to the 'gce-image-builder'
+  By default this template is setup to publish to the 'ciq-build-images'
   project, the 'environment' variable can be used to publish to 'test', 'prod'
   DeleteAfter is set to 180 days for all environments other than prod where no
   time period is set.
 */}}
 {
   "Name": "rocky-linux-9-arm64",
-  {{$work_project := printf "%q" "gce-image-builder" -}}
+  {{$work_project := printf "%q" "ciq-build-images" -}}
   {{$endpoint := `"https://www.googleapis.com/compute/alpha/projects/"` -}}
   {{$delete_after := `"24h*30*2"` -}}
   {{if eq .environment "test" -}}
   "WorkProject": {{$work_project}},
-  "PublishProject": "bct-prod-images",
+  "PublishProject": "gce-ciq-images",
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- else if eq .environment "prod" -}}

--- a/publish/rocky/9/rocky_linux_9_arm64.wf.json
+++ b/publish/rocky/9/rocky_linux_9_arm64.wf.json
@@ -17,7 +17,7 @@
       "Description": "Root of github workflows, defaults to /workflows in the container."
     },
     "gcs_url": {
-      "Required": true,
+      "Value": "gs://gce-ciq-images-prod-artifacts/${NAME}-v${TIMESTAMP}.tar.gz",
       "Description": "The GCS path that image raw file exported to."
     },
     "sbom_destination": {
@@ -25,7 +25,7 @@
       "Description": "SBOM final export destination, copies in place by default"
     },
     "installer_iso": {
-      "Required": true,
+      "Value": "gs://gce-ciq-images-base-isos/Rocky-9-aarch64-boot.iso",
       "Description": "The Rocky Linux 9 installer ISO to build from."
     },
     "sbom_util_gcs_root": {

--- a/publish/rocky/9/rocky_linux_9_arm64.wf.json
+++ b/publish/rocky/9/rocky_linux_9_arm64.wf.json
@@ -1,7 +1,7 @@
 {
   "Name": "rocky-linux-9-arm64",
   "Project": "gce-ciq-images",
-  "Zone": "us-central1-b",
+  "Zone": "europe-west4-a",
   "GCSPath": "gs://gce-ciq-images-build-bucket/daisy/${USERNAME}",
   "Vars": {
     "build_date": {

--- a/publish/rocky/9/rocky_linux_9_arm64.wf.json
+++ b/publish/rocky/9/rocky_linux_9_arm64.wf.json
@@ -1,8 +1,8 @@
 {
   "Name": "rocky-linux-9-arm64",
-  "Project": "gce-image-builder",
+  "Project": "gce-ciq-images",
   "Zone": "us-central1-b",
-  "GCSPath": "gs://gce-image-build-bucket/daisy/${USERNAME}",
+  "GCSPath": "gs://gce-ciq-images-build-bucket/daisy/${USERNAME}",
   "Vars": {
     "build_date": {
       "Value": "${TIMESTAMP}",
@@ -41,7 +41,7 @@
     "build": {
       "TimeOut": "60m",
       "IncludeWorkflow": {
-        "Path": "${workflow_root}/image_build/enterprise_linux/rocky_linux_9_arm64.wf.json",
+        "Path": "${workflow_root}/rocky/9/rocky_linux_9_arm64.wf.json",
         "Vars": {
           "build_date": "${build_date}",
           "google_cloud_repo": "${google_cloud_repo}",

--- a/publish/rocky/9/rocky_linux_9_optimized_gcp.publish.json
+++ b/publish/rocky/9/rocky_linux_9_optimized_gcp.publish.json
@@ -1,18 +1,18 @@
 {{/*
   Template to publish UEFI-enabled Rocky Linux images.
-  By default this template is setup to publish to the 'gce-image-builder'
+  By default this template is setup to publish to the 'ciq-build-images'
   project, the 'environment' variable can be used to publish to 'test', 'prod'
   DeleteAfter is set to 180 days for all environments other than prod where no
   time period is set.
 */}}
 {
   "Name": "rocky-linux-9-optimized-gcp",
-  {{$work_project := printf "%q" "gce-image-builder" -}}
+  {{$work_project := printf "%q" "ciq-build-images" -}}
   {{$endpoint := `"https://www.googleapis.com/compute/alpha/projects/"` -}}
   {{$delete_after := `"24h*30*2"` -}}
   {{if eq .environment "test" -}}
   "WorkProject": {{$work_project}},
-  "PublishProject": "bct-prod-images",
+  "PublishProject": "gce-ciq-images",
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- else if eq .environment "prod" -}}

--- a/publish/rocky/9/rocky_linux_9_optimized_gcp.wf.json
+++ b/publish/rocky/9/rocky_linux_9_optimized_gcp.wf.json
@@ -17,7 +17,7 @@
       "Description": "Root of github workflows, defaults to /workflows in the container."
     },
     "gcs_url": {
-      "Required": true,
+      "Value": "gs://gce-ciq-images-prod-artifacts/${NAME}-v${TIMESTAMP}.tar.gz",
       "Description": "The GCS path that image raw file exported to."
     },
     "sbom_destination": {
@@ -25,7 +25,7 @@
       "Description": "SBOM final export destination, copies in place by default"
     },
     "installer_iso": {
-      "Required": true,
+      "Value": "gs://gce-ciq-images-base-isos/Rocky-9-x86_64-boot.iso",
       "Description": "The Rocky Linux 9 installer ISO to build from."
     },
     "sbom_util_gcs_root": {

--- a/publish/rocky/9/rocky_linux_9_optimized_gcp.wf.json
+++ b/publish/rocky/9/rocky_linux_9_optimized_gcp.wf.json
@@ -1,8 +1,8 @@
 {
   "Name": "rocky-linux-9-optimized-gcp",
-  "Project": "gce-image-builder",
+  "Project": "gce-ciq-images",
   "Zone": "us-central1-b",
-  "GCSPath": "gs://gce-image-build-bucket/daisy/${USERNAME}",
+  "GCSPath": "gs://gce-ciq-images-build-bucket/daisy/${USERNAME}",
   "Vars": {
     "build_date": {
       "Value": "${TIMESTAMP}",
@@ -41,7 +41,7 @@
     "build": {
       "TimeOut": "60m",
       "IncludeWorkflow": {
-        "Path": "${workflow_root}/image_build/enterprise_linux/rocky_linux_9_optimized_gcp.wf.json",
+        "Path": "${workflow_root}/rocky/9/rocky_linux_9_optimized_gcp.wf.json",
         "Vars": {
           "build_date": "${build_date}",
           "installer_iso": "${installer_iso}"

--- a/publish/rocky/9/rocky_linux_9_optimized_gcp.wf.json
+++ b/publish/rocky/9/rocky_linux_9_optimized_gcp.wf.json
@@ -1,7 +1,7 @@
 {
   "Name": "rocky-linux-9-optimized-gcp",
   "Project": "gce-ciq-images",
-  "Zone": "us-central1-b",
+  "Zone": "europe-west4-a",
   "GCSPath": "gs://gce-ciq-images-build-bucket/daisy/${USERNAME}",
   "Vars": {
     "build_date": {

--- a/publish/rocky/9/rocky_linux_9_optimized_gcp_arm64.publish.json
+++ b/publish/rocky/9/rocky_linux_9_optimized_gcp_arm64.publish.json
@@ -1,18 +1,18 @@
 {{/*
   Template to publish UEFI-enabled Rocky Linux images.
-  By default this template is setup to publish to the 'gce-image-builder'
+  By default this template is setup to publish to the 'ciq-build-images'
   project, the 'environment' variable can be used to publish to 'test', 'prod'
   DeleteAfter is set to 180 days for all environments other than prod where no
   time period is set.
 */}}
 {
   "Name": "rocky-linux-9-optimized-gcp-arm64",
-  {{$work_project := printf "%q" "gce-image-builder" -}}
+  {{$work_project := printf "%q" "ciq-build-images" -}}
   {{$endpoint := `"https://www.googleapis.com/compute/alpha/projects/"` -}}
   {{$delete_after := `"24h*30*2"` -}}
   {{if eq .environment "test" -}}
   "WorkProject": {{$work_project}},
-  "PublishProject": "bct-prod-images",
+  "PublishProject": "gce-ciq-images",
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- else if eq .environment "prod" -}}

--- a/publish/rocky/9/rocky_linux_9_optimized_gcp_arm64.wf.json
+++ b/publish/rocky/9/rocky_linux_9_optimized_gcp_arm64.wf.json
@@ -17,7 +17,7 @@
       "Description": "Root of github workflows, defaults to /workflows in the container."
     },
     "gcs_url": {
-      "Required": true,
+      "Value": "gs://gce-ciq-images-prod-artifacts/${NAME}-v${TIMESTAMP}.tar.gz",
       "Description": "The GCS path that image raw file exported to."
     },
     "sbom_destination": {
@@ -25,7 +25,7 @@
       "Description": "SBOM final export destination, copies in place by default"
     },
     "installer_iso": {
-      "Required": true,
+      "Value": "gs://gce-ciq-images-base-isos/Rocky-9-aarch64-boot.iso",
       "Description": "The Rocky Linux 9 installer ISO to build from."
     },
     "sbom_util_gcs_root": {

--- a/publish/rocky/9/rocky_linux_9_optimized_gcp_arm64.wf.json
+++ b/publish/rocky/9/rocky_linux_9_optimized_gcp_arm64.wf.json
@@ -1,8 +1,8 @@
 {
   "Name": "rocky-linux-9-optimized-gcp-arm64",
-  "Project": "gce-image-builder",
+  "Project": "gce-ciq-images",
   "Zone": "us-central1-b",
-  "GCSPath": "gs://gce-image-build-bucket/daisy/${USERNAME}",
+  "GCSPath": "gs://gce-ciq-images-build-bucket/daisy/${USERNAME}",
   "Vars": {
     "build_date": {
       "Value": "${TIMESTAMP}",
@@ -41,7 +41,7 @@
     "build": {
       "TimeOut": "60m",
       "IncludeWorkflow": {
-        "Path": "${workflow_root}/image_build/enterprise_linux/rocky_linux_9_optimized_gcp_arm64.wf.json",
+        "Path": "${workflow_root}/rocky/9/rocky_linux_9_optimized_gcp_arm64.wf.json",
         "Vars": {
           "build_date": "${build_date}",
           "installer_iso": "${installer_iso}"

--- a/publish/rocky/9/rocky_linux_9_optimized_gcp_arm64.wf.json
+++ b/publish/rocky/9/rocky_linux_9_optimized_gcp_arm64.wf.json
@@ -1,7 +1,7 @@
 {
   "Name": "rocky-linux-9-optimized-gcp-arm64",
   "Project": "gce-ciq-images",
-  "Zone": "us-central1-b",
+  "Zone": "europe-west4-a",
   "GCSPath": "gs://gce-ciq-images-build-bucket/daisy/${USERNAME}",
   "Vars": {
     "build_date": {

--- a/publish/rocky/9/rocky_linux_9_optimized_gcp_nvidia_550.publish.json
+++ b/publish/rocky/9/rocky_linux_9_optimized_gcp_nvidia_550.publish.json
@@ -1,18 +1,18 @@
 {{/*
   Template to publish Rocky 9 optimized for GCP/Nvidia images.
-  By default this template is setup to publish to the 'gce-image-builder'
+  By default this template is setup to publish to the 'ciq-build-images'
   project, the 'environment' variable can be used to publish to 'test', 'prod'
   DeleteAfter is set to 190 days for all environments other than prod where no
   time period is set.
 */}}
 {
   "Name": "rocky-linux-9-optimized-gcp-nvidia-550",
-  {{$work_project := printf "%q" "gce-image-builder" -}}
+  {{$work_project := printf "%q" "ciq-build-images" -}}
   {{$endpoint := `"https://www.googleapis.com/compute/alpha/projects/"` -}}
   {{$delete_after := `"24h*30*2"` -}}
   {{if eq .environment "test" -}}
   "WorkProject": {{$work_project}},
-  "PublishProject": "bct-prod-images",
+  "PublishProject": "gce-ciq-images",
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- else if eq .environment "prod" -}}

--- a/publish/rocky/9/rocky_linux_9_optimized_gcp_nvidia_550.wf.json
+++ b/publish/rocky/9/rocky_linux_9_optimized_gcp_nvidia_550.wf.json
@@ -17,7 +17,7 @@
       "Description": "Root of github workflows, defaults to /workflows in the container."
     },
     "gcs_url": {
-      "Required": true,
+      "Value": "gs://gce-ciq-images-prod-artifacts/${NAME}-v${TIMESTAMP}.tar.gz",
       "Description": "The GCS path that image raw file exported to."
     },
     "sbom_destination": {
@@ -25,7 +25,7 @@
       "Description": "SBOM final export destination, copies in place by default"
     },
     "installer_iso": {
-      "Required": true,
+      "Value": "gs://gce-ciq-images-base-isos/Rocky-9-x86_64-boot.iso",
       "Description": "The Rocky Linux 9 installer ISO to build from."
     },
     "sbom_util_gcs_root": {

--- a/publish/rocky/9/rocky_linux_9_optimized_gcp_nvidia_550.wf.json
+++ b/publish/rocky/9/rocky_linux_9_optimized_gcp_nvidia_550.wf.json
@@ -1,7 +1,7 @@
 {
   "Name": "rocky-linux-9-optimized-gcp-nvidia-550",
   "Project": "gce-ciq-images",
-  "Zone": "us-central1-b",
+  "Zone": "europe-west4-a",
   "GCSPath": "gs://gce-ciq-images-build-bucket/daisy/${USERNAME}",
   "Vars": {
     "build_date": {

--- a/publish/rocky/9/rocky_linux_9_optimized_gcp_nvidia_550.wf.json
+++ b/publish/rocky/9/rocky_linux_9_optimized_gcp_nvidia_550.wf.json
@@ -1,8 +1,8 @@
 {
   "Name": "rocky-linux-9-optimized-gcp-nvidia-550",
-  "Project": "gce-image-builder",
+  "Project": "gce-ciq-images",
   "Zone": "us-central1-b",
-  "GCSPath": "gs://gce-image-build-bucket/daisy/${USERNAME}",
+  "GCSPath": "gs://gce-ciq-images-build-bucket/daisy/${USERNAME}",
   "Vars": {
     "build_date": {
       "Value": "${TIMESTAMP}",
@@ -41,7 +41,7 @@
     "build": {
       "TimeOut": "60m",
       "IncludeWorkflow": {
-        "Path": "${workflow_root}/image_build/enterprise_linux/rocky_linux_9_optimized_gcp_nvidia_550.wf.json",
+        "Path": "${workflow_root}/rocky/9/rocky_linux_9_optimized_gcp_nvidia_550.wf.json",
         "Vars": {
           "build_date": "${build_date}",
           "installer_iso": "${installer_iso}"

--- a/publish/rocky/9/rocky_linux_9_optimized_gcp_nvidia_570.publish.json
+++ b/publish/rocky/9/rocky_linux_9_optimized_gcp_nvidia_570.publish.json
@@ -1,18 +1,18 @@
 {{/*
   Template to publish Rocky 9 optimized for GCP/Nvidia images.
-  By default this template is setup to publish to the 'gce-image-builder'
+  By default this template is setup to publish to the 'ciq-build-images'
   project, the 'environment' variable can be used to publish to 'test', 'prod'
   DeleteAfter is set to 190 days for all environments other than prod where no
   time period is set.
 */}}
 {
   "Name": "rocky-linux-9-optimized-gcp-nvidia-570",
-  {{$work_project := printf "%q" "gce-image-builder" -}}
+  {{$work_project := printf "%q" "ciq-build-images" -}}
   {{$endpoint := `"https://www.googleapis.com/compute/alpha/projects/"` -}}
   {{$delete_after := `"24h*30*2"` -}}
   {{if eq .environment "test" -}}
   "WorkProject": {{$work_project}},
-  "PublishProject": "bct-prod-images",
+  "PublishProject": "gce-ciq-images",
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- else if eq .environment "prod" -}}

--- a/publish/rocky/9/rocky_linux_9_optimized_gcp_nvidia_570.wf.json
+++ b/publish/rocky/9/rocky_linux_9_optimized_gcp_nvidia_570.wf.json
@@ -17,7 +17,7 @@
       "Description": "Root of github workflows, defaults to /workflows in the container."
     },
     "gcs_url": {
-      "Required": true,
+      "Value": "gs://gce-ciq-images-prod-artifacts/${NAME}-v${TIMESTAMP}.tar.gz",
       "Description": "The GCS path that image raw file exported to."
     },
     "sbom_destination": {
@@ -25,7 +25,7 @@
       "Description": "SBOM final export destination, copies in place by default"
     },
     "installer_iso": {
-      "Required": true,
+      "Value": "gs://gce-ciq-images-base-isos/Rocky-9-x86_64-boot.iso",
       "Description": "The Rocky Linux 9 installer ISO to build from."
     },
     "sbom_util_gcs_root": {

--- a/publish/rocky/9/rocky_linux_9_optimized_gcp_nvidia_570.wf.json
+++ b/publish/rocky/9/rocky_linux_9_optimized_gcp_nvidia_570.wf.json
@@ -1,7 +1,7 @@
 {
   "Name": "rocky-linux-9-optimized-gcp-nvidia-570",
   "Project": "gce-ciq-images",
-  "Zone": "us-central1-b",
+  "Zone": "europe-west4-a",
   "GCSPath": "gs://gce-ciq-images-build-bucket/daisy/${USERNAME}",
   "Vars": {
     "build_date": {

--- a/publish/rocky/9/rocky_linux_9_optimized_gcp_nvidia_570.wf.json
+++ b/publish/rocky/9/rocky_linux_9_optimized_gcp_nvidia_570.wf.json
@@ -1,8 +1,8 @@
 {
   "Name": "rocky-linux-9-optimized-gcp-nvidia-570",
-  "Project": "gce-image-builder",
+  "Project": "gce-ciq-images",
   "Zone": "us-central1-b",
-  "GCSPath": "gs://gce-image-build-bucket/daisy/${USERNAME}",
+  "GCSPath": "gs://gce-ciq-images-build-bucket/daisy/${USERNAME}",
   "Vars": {
     "build_date": {
       "Value": "${TIMESTAMP}",
@@ -41,7 +41,7 @@
     "build": {
       "TimeOut": "60m",
       "IncludeWorkflow": {
-        "Path": "${workflow_root}/image_build/enterprise_linux/rocky_linux_9_optimized_gcp_nvidia_570.wf.json",
+        "Path": "${workflow_root}/rocky/9/rocky_linux_9_optimized_gcp_nvidia_570.wf.json",
         "Vars": {
           "build_date": "${build_date}",
           "installer_iso": "${installer_iso}"

--- a/publish/rocky/9/rocky_linux_9_optimized_gcp_nvidia_latest.publish.json
+++ b/publish/rocky/9/rocky_linux_9_optimized_gcp_nvidia_latest.publish.json
@@ -1,18 +1,18 @@
 {{/*
   Template to publish Rocky 9 optimized for GCP/Nvidia images.
-  By default this template is setup to publish to the 'gce-image-builder'
+  By default this template is setup to publish to the 'ciq-build-images'
   project, the 'environment' variable can be used to publish to 'test', 'prod'
   DeleteAfter is set to 190 days for all environments other than prod where no
   time period is set.
 */}}
 {
   "Name": "rocky-linux-9-optimized-gcp-nvidia-latest",
-  {{$work_project := printf "%q" "gce-image-builder" -}}
+  {{$work_project := printf "%q" "ciq-build-images" -}}
   {{$endpoint := `"https://www.googleapis.com/compute/alpha/projects/"` -}}
   {{$delete_after := `"24h*30*2"` -}}
   {{if eq .environment "test" -}}
   "WorkProject": {{$work_project}},
-  "PublishProject": "bct-prod-images",
+  "PublishProject": "gce-ciq-images",
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- else if eq .environment "prod" -}}

--- a/publish/rocky/9/rocky_linux_9_optimized_gcp_nvidia_latest.wf.json
+++ b/publish/rocky/9/rocky_linux_9_optimized_gcp_nvidia_latest.wf.json
@@ -17,7 +17,7 @@
       "Description": "Root of github workflows, defaults to /workflows in the container."
     },
     "gcs_url": {
-      "Required": true,
+      "Value": "gs://gce-ciq-images-prod-artifacts/${NAME}-v${TIMESTAMP}.tar.gz",
       "Description": "The GCS path that image raw file exported to."
     },
     "sbom_destination": {
@@ -25,7 +25,7 @@
       "Description": "SBOM final export destination, copies in place by default"
     },
     "installer_iso": {
-      "Required": true,
+      "Value": "gs://gce-ciq-images-base-isos/Rocky-9-x86_64-boot.iso",
       "Description": "The Rocky Linux 9 installer ISO to build from."
     },
     "sbom_util_gcs_root": {

--- a/publish/rocky/9/rocky_linux_9_optimized_gcp_nvidia_latest.wf.json
+++ b/publish/rocky/9/rocky_linux_9_optimized_gcp_nvidia_latest.wf.json
@@ -1,8 +1,8 @@
 {
   "Name": "rocky-linux-9-optimized-gcp-nvidia-latest",
-  "Project": "gce-image-builder",
+  "Project": "gce-ciq-images",
   "Zone": "us-central1-b",
-  "GCSPath": "gs://gce-image-build-bucket/daisy/${USERNAME}",
+  "GCSPath": "gs://gce-ciq-images-build-bucket/daisy/${USERNAME}",
   "Vars": {
     "build_date": {
       "Value": "${TIMESTAMP}",
@@ -41,7 +41,7 @@
     "build": {
       "TimeOut": "60m",
       "IncludeWorkflow": {
-        "Path": "${workflow_root}/image_build/enterprise_linux/rocky_linux_9_optimized_gcp_nvidia_latest.wf.json",
+        "Path": "${workflow_root}/rocky/9/rocky_linux_9_optimized_gcp_nvidia_latest.wf.json",
         "Vars": {
           "build_date": "${build_date}",
           "installer_iso": "${installer_iso}"

--- a/publish/rocky/9/rocky_linux_9_optimized_gcp_nvidia_latest.wf.json
+++ b/publish/rocky/9/rocky_linux_9_optimized_gcp_nvidia_latest.wf.json
@@ -1,7 +1,7 @@
 {
   "Name": "rocky-linux-9-optimized-gcp-nvidia-latest",
   "Project": "gce-ciq-images",
-  "Zone": "us-central1-b",
+  "Zone": "europe-west4-a",
   "GCSPath": "gs://gce-ciq-images-build-bucket/daisy/${USERNAME}",
   "Vars": {
     "build_date": {


### PR DESCRIPTION
This has the following fixes required to move this to a new project:
- Updating the publish paths and buckets to CIQ's buckets
- Add sane default values for the images
- Remove unnecessary python38 workaround for ARM64 image
- Name optimized image builds so they're consistent with the rest

We're also adding in configs to build the vanilla Rocky 8 ARM64 image.  This image has been tested in the CIT test suite and is fully functional.