### PR TITLE
Exclude all `kernel*` packages from BaseOS when doing initial install

### DIFF
--- a/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp.cfg
+++ b/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp.cfg
@@ -4,7 +4,7 @@
 # Install in text mode.
 text --non-interactive
 url --url="https://depot.ciq.com/public/download/ciq-sigcloud-next-10/ciq-sigcloud-next-10.x86_64"
-repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/10/BaseOS/x86_64/os" --excludepkgs="kernel,kernel-core"
+repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/10/BaseOS/x86_64/os" --excludepkgs="kernel*"
 repo --name=AppStream --baseurl="https://dl.rockylinux.org/pub/rocky/10/AppStream/x86_64/os"
 repo --name=CRB --baseurl="https://dl.rockylinux.org/pub/rocky/10/CRB/x86_64/os"
 poweroff

--- a/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp_accelerator.cfg
+++ b/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp_accelerator.cfg
@@ -5,7 +5,7 @@
 text --non-interactive
 url --url="https://depot.ciq.com/public/download/ciq-sigcloud-next-10/ciq-sigcloud-next-10.x86_64"
 repo --name=ciq-sigcloud-next-nonfree-8 --baseurl="https://depot.ciq.com/public/download/ciq-sigcloud-next-10/ciq-sigcloud-next-10-nonfree.x86_64"
-repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/10/BaseOS/x86_64/os" --excludepkgs="kernel,kernel-core"
+repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/10/BaseOS/x86_64/os" --excludepkgs="kernel*"
 repo --name=AppStream --baseurl="https://dl.rockylinux.org/pub/rocky/10/AppStream/x86_64/os"
 repo --name=CRB --baseurl="https://dl.rockylinux.org/pub/rocky/10/CRB/x86_64/os"
 poweroff

--- a/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp_accelerator_570.cfg
+++ b/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp_accelerator_570.cfg
@@ -5,7 +5,7 @@
 text --non-interactive
 url --url="https://depot.ciq.com/public/download/ciq-sigcloud-next-10/ciq-sigcloud-next-10.x86_64"
 repo --name=ciq-sigcloud-next-nonfree-8 --baseurl="https://depot.ciq.com/public/download/ciq-sigcloud-next-10/ciq-sigcloud-next-10-nonfree.x86_64"
-repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/10/BaseOS/x86_64/os" --excludepkgs="kernel,kernel-core"
+repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/10/BaseOS/x86_64/os" --excludepkgs="kernel*"
 repo --name=AppStream --baseurl="https://dl.rockylinux.org/pub/rocky/10/AppStream/x86_64/os"
 repo --name=CRB --baseurl="https://dl.rockylinux.org/pub/rocky/10/CRB/x86_64/os"
 poweroff

--- a/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp_accelerator_570_arm64.cfg
+++ b/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp_accelerator_570_arm64.cfg
@@ -5,7 +5,7 @@
 text --non-interactive
 url --url="https://depot.ciq.com/public/download/ciq-sigcloud-next-10/ciq-sigcloud-next-10.aarch64"
 repo --name=ciq-sigcloud-next-nonfree-8 --baseurl="https://depot.ciq.com/public/download/ciq-sigcloud-next-10/ciq-sigcloud-next-10-nonfree.aarch64"
-repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/10/BaseOS/aarch64/os" --excludepkgs="kernel,kernel-core"
+repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/10/BaseOS/aarch64/os" --excludepkgs="kernel*"
 repo --name=AppStream --baseurl="https://dl.rockylinux.org/pub/rocky/10/AppStream/aarch64/os"
 repo --name=CRB --baseurl="https://dl.rockylinux.org/pub/rocky/10/CRB/aarch64/os"
 poweroff

--- a/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp_accelerator_580.cfg
+++ b/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp_accelerator_580.cfg
@@ -5,7 +5,7 @@
 text --non-interactive
 url --url="https://depot.ciq.com/public/download/ciq-sigcloud-next-10/ciq-sigcloud-next-10.x86_64"
 repo --name=ciq-sigcloud-next-nonfree-8 --baseurl="https://depot.ciq.com/public/download/ciq-sigcloud-next-10/ciq-sigcloud-next-10-nonfree.x86_64"
-repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/10/BaseOS/x86_64/os" --excludepkgs="kernel,kernel-core"
+repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/10/BaseOS/x86_64/os" --excludepkgs="kernel*"
 repo --name=AppStream --baseurl="https://dl.rockylinux.org/pub/rocky/10/AppStream/x86_64/os"
 repo --name=CRB --baseurl="https://dl.rockylinux.org/pub/rocky/10/CRB/x86_64/os"
 poweroff

--- a/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp_accelerator_580_arm64.cfg
+++ b/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp_accelerator_580_arm64.cfg
@@ -5,7 +5,7 @@
 text --non-interactive
 url --url="https://depot.ciq.com/public/download/ciq-sigcloud-next-10/ciq-sigcloud-next-10.aarch64"
 repo --name=ciq-sigcloud-next-nonfree-8 --baseurl="https://depot.ciq.com/public/download/ciq-sigcloud-next-10/ciq-sigcloud-next-10-nonfree.aarch64"
-repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/10/BaseOS/aarch64/os" --excludepkgs="kernel,kernel-core"
+repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/10/BaseOS/aarch64/os" --excludepkgs="kernel*"
 repo --name=AppStream --baseurl="https://dl.rockylinux.org/pub/rocky/10/AppStream/aarch64/os"
 repo --name=CRB --baseurl="https://dl.rockylinux.org/pub/rocky/10/CRB/aarch64/os"
 poweroff

--- a/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp_accelerator_arm64.cfg
+++ b/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp_accelerator_arm64.cfg
@@ -5,7 +5,7 @@
 text --non-interactive
 url --url="https://depot.ciq.com/public/download/ciq-sigcloud-next-10/ciq-sigcloud-next-10.aarch64"
 repo --name=ciq-sigcloud-next-nonfree-8 --baseurl="https://depot.ciq.com/public/download/ciq-sigcloud-next-10/ciq-sigcloud-next-10-nonfree.aarch64"
-repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/10/BaseOS/aarch64/os" --excludepkgs="kernel,kernel-core"
+repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/10/BaseOS/aarch64/os" --excludepkgs="kernel*"
 repo --name=AppStream --baseurl="https://dl.rockylinux.org/pub/rocky/10/AppStream/aarch64/os"
 repo --name=CRB --baseurl="https://dl.rockylinux.org/pub/rocky/10/CRB/aarch64/os"
 poweroff

--- a/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp_arm64.cfg
+++ b/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp_arm64.cfg
@@ -4,7 +4,7 @@
 # Install in text mode.
 text --non-interactive
 url --url="https://depot.ciq.com/public/download/ciq-sigcloud-next-10/ciq-sigcloud-next-10.aarch64"
-repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/10/BaseOS/aarch64/os" --excludepkgs="kernel, kernel-core"
+repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/10/BaseOS/aarch64/os" --excludepkgs="kernel*"
 repo --name=AppStream --baseurl="https://dl.rockylinux.org/pub/rocky/10/AppStream/aarch64/os"
 repo --name=CRB --baseurl="https://dl.rockylinux.org/pub/rocky/10/CRB/aarch64/os"
 poweroff


### PR DESCRIPTION
When Rocky has a newer version of the kernel than SIG/Cloud Next, `kernel-uki-virt` from Rocky is installed rather than `kernel` from SCN. This commit fixes that by excluding all kernel packages in BaseOS rather than just kernel and kernel-core