### PR TITLE
Switch images using SCN 10 to use new location

### DIFF
--- a/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp.cfg
+++ b/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp.cfg
@@ -3,7 +3,7 @@
 ### Anaconda installer configuration.
 # Install in text mode.
 text --non-interactive
-url --url="https://depot.ciq.com/public/download/ciq-sigcloud-next-10/ciq-sigcloud-next-10.x86_64"
+url --url="https://depot.ciq.com/public/download/ciq-scn-10/ciq-scn-10.x86_64"
 repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/10/BaseOS/x86_64/os" --excludepkgs="kernel*"
 repo --name=AppStream --baseurl="https://dl.rockylinux.org/pub/rocky/10/AppStream/x86_64/os"
 repo --name=CRB --baseurl="https://dl.rockylinux.org/pub/rocky/10/CRB/x86_64/os"

--- a/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp_accelerator.cfg
+++ b/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp_accelerator.cfg
@@ -3,8 +3,8 @@
 ### Anaconda installer configuration.
 # Install in text mode.
 text --non-interactive
-url --url="https://depot.ciq.com/public/download/ciq-sigcloud-next-10/ciq-sigcloud-next-10.x86_64"
-repo --name=ciq-sigcloud-next-nonfree-8 --baseurl="https://depot.ciq.com/public/download/ciq-sigcloud-next-10/ciq-sigcloud-next-10-nonfree.x86_64"
+url --url="https://depot.ciq.com/public/download/ciq-scn-10/ciq-scn-10.x86_64"
+repo --name=ciq-sigcloud-next-nonfree-10 --baseurl="https://depot.ciq.com/public/download/ciq-scn-10/ciq-scn-10-nonfree.x86_64"
 repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/10/BaseOS/x86_64/os" --excludepkgs="kernel*"
 repo --name=AppStream --baseurl="https://dl.rockylinux.org/pub/rocky/10/AppStream/x86_64/os"
 repo --name=CRB --baseurl="https://dl.rockylinux.org/pub/rocky/10/CRB/x86_64/os"

--- a/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp_accelerator_570.cfg
+++ b/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp_accelerator_570.cfg
@@ -3,8 +3,8 @@
 ### Anaconda installer configuration.
 # Install in text mode.
 text --non-interactive
-url --url="https://depot.ciq.com/public/download/ciq-sigcloud-next-10/ciq-sigcloud-next-10.x86_64"
-repo --name=ciq-sigcloud-next-nonfree-8 --baseurl="https://depot.ciq.com/public/download/ciq-sigcloud-next-10/ciq-sigcloud-next-10-nonfree.x86_64"
+url --url="https://depot.ciq.com/public/download/ciq-scn-10/ciq-scn-10.x86_64"
+repo --name=ciq-sigcloud-next-nonfree-10 --baseurl="https://depot.ciq.com/public/download/ciq-scn-10/ciq-scn-10-nonfree.x86_64"
 repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/10/BaseOS/x86_64/os" --excludepkgs="kernel*"
 repo --name=AppStream --baseurl="https://dl.rockylinux.org/pub/rocky/10/AppStream/x86_64/os"
 repo --name=CRB --baseurl="https://dl.rockylinux.org/pub/rocky/10/CRB/x86_64/os"

--- a/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp_accelerator_570_arm64.cfg
+++ b/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp_accelerator_570_arm64.cfg
@@ -3,8 +3,8 @@
 ### Anaconda installer configuration.
 # Install in text mode.
 text --non-interactive
-url --url="https://depot.ciq.com/public/download/ciq-sigcloud-next-10/ciq-sigcloud-next-10.aarch64"
-repo --name=ciq-sigcloud-next-nonfree-8 --baseurl="https://depot.ciq.com/public/download/ciq-sigcloud-next-10/ciq-sigcloud-next-10-nonfree.aarch64"
+url --url="https://depot.ciq.com/public/download/ciq-scn-10/ciq-scn-10.aarch64"
+repo --name=ciq-sigcloud-next-nonfree-10 --baseurl="https://depot.ciq.com/public/download/ciq-scn-10/ciq-scn-10-nonfree.aarch64"
 repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/10/BaseOS/aarch64/os" --excludepkgs="kernel*"
 repo --name=AppStream --baseurl="https://dl.rockylinux.org/pub/rocky/10/AppStream/aarch64/os"
 repo --name=CRB --baseurl="https://dl.rockylinux.org/pub/rocky/10/CRB/aarch64/os"

--- a/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp_accelerator_580.cfg
+++ b/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp_accelerator_580.cfg
@@ -3,8 +3,8 @@
 ### Anaconda installer configuration.
 # Install in text mode.
 text --non-interactive
-url --url="https://depot.ciq.com/public/download/ciq-sigcloud-next-10/ciq-sigcloud-next-10.x86_64"
-repo --name=ciq-sigcloud-next-nonfree-8 --baseurl="https://depot.ciq.com/public/download/ciq-sigcloud-next-10/ciq-sigcloud-next-10-nonfree.x86_64"
+url --url="https://depot.ciq.com/public/download/ciq-scn-10/ciq-scn-10.x86_64"
+repo --name=ciq-sigcloud-next-nonfree-10 --baseurl="https://depot.ciq.com/public/download/ciq-scn-10/ciq-scn-10-nonfree.x86_64"
 repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/10/BaseOS/x86_64/os" --excludepkgs="kernel*"
 repo --name=AppStream --baseurl="https://dl.rockylinux.org/pub/rocky/10/AppStream/x86_64/os"
 repo --name=CRB --baseurl="https://dl.rockylinux.org/pub/rocky/10/CRB/x86_64/os"

--- a/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp_accelerator_580_arm64.cfg
+++ b/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp_accelerator_580_arm64.cfg
@@ -3,8 +3,8 @@
 ### Anaconda installer configuration.
 # Install in text mode.
 text --non-interactive
-url --url="https://depot.ciq.com/public/download/ciq-sigcloud-next-10/ciq-sigcloud-next-10.aarch64"
-repo --name=ciq-sigcloud-next-nonfree-8 --baseurl="https://depot.ciq.com/public/download/ciq-sigcloud-next-10/ciq-sigcloud-next-10-nonfree.aarch64"
+url --url="https://depot.ciq.com/public/download/ciq-scn-10/ciq-scn-10.aarch64"
+repo --name=ciq-sigcloud-next-nonfree-10 --baseurl="https://depot.ciq.com/public/download/ciq-scn-10/ciq-scn-10-nonfree.aarch64"
 repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/10/BaseOS/aarch64/os" --excludepkgs="kernel*"
 repo --name=AppStream --baseurl="https://dl.rockylinux.org/pub/rocky/10/AppStream/aarch64/os"
 repo --name=CRB --baseurl="https://dl.rockylinux.org/pub/rocky/10/CRB/aarch64/os"

--- a/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp_accelerator_arm64.cfg
+++ b/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp_accelerator_arm64.cfg
@@ -3,8 +3,8 @@
 ### Anaconda installer configuration.
 # Install in text mode.
 text --non-interactive
-url --url="https://depot.ciq.com/public/download/ciq-sigcloud-next-10/ciq-sigcloud-next-10.aarch64"
-repo --name=ciq-sigcloud-next-nonfree-8 --baseurl="https://depot.ciq.com/public/download/ciq-sigcloud-next-10/ciq-sigcloud-next-10-nonfree.aarch64"
+url --url="https://depot.ciq.com/public/download/ciq-scn-10/ciq-scn-10.aarch64"
+repo --name=ciq-sigcloud-next-nonfree-10 --baseurl="https://depot.ciq.com/public/download/ciq-scn-10/ciq-scn-10-nonfree.aarch64"
 repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/10/BaseOS/aarch64/os" --excludepkgs="kernel*"
 repo --name=AppStream --baseurl="https://dl.rockylinux.org/pub/rocky/10/AppStream/aarch64/os"
 repo --name=CRB --baseurl="https://dl.rockylinux.org/pub/rocky/10/CRB/aarch64/os"

--- a/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp_arm64.cfg
+++ b/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp_arm64.cfg
@@ -3,7 +3,7 @@
 ### Anaconda installer configuration.
 # Install in text mode.
 text --non-interactive
-url --url="https://depot.ciq.com/public/download/ciq-sigcloud-next-10/ciq-sigcloud-next-10.aarch64"
+url --url="https://depot.ciq.com/public/download/ciq-scn-10/ciq-scn-10.aarch64"
 repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/10/BaseOS/aarch64/os" --excludepkgs="kernel*"
 repo --name=AppStream --baseurl="https://dl.rockylinux.org/pub/rocky/10/AppStream/aarch64/os"
 repo --name=CRB --baseurl="https://dl.rockylinux.org/pub/rocky/10/CRB/aarch64/os"

--- a/daisy/rocky/9/kickstart/rocky_linux_9_optimized_gcp_accelerator.cfg
+++ b/daisy/rocky/9/kickstart/rocky_linux_9_optimized_gcp_accelerator.cfg
@@ -4,7 +4,7 @@
 # Install in text mode.
 text --non-interactive
 url --url="https://depot.ciq.com/public/download/ciq-sigcloud-next-9/ciq-sigcloud-next-9.x86_64"
-repo --name=ciq-sigcloud-next-nonfree-8 --baseurl="https://depot.ciq.com/public/download/ciq-sigcloud-next-9/ciq-sigcloud-next-9-nonfree.x86_64"
+repo --name=ciq-sigcloud-next-nonfree-9 --baseurl="https://depot.ciq.com/public/download/ciq-sigcloud-next-9/ciq-sigcloud-next-9-nonfree.x86_64"
 repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os" --excludepkgs="kernel,kernel-core"
 repo --name=AppStream --baseurl="https://dl.rockylinux.org/pub/rocky/9/AppStream/x86_64/os"
 repo --name=CRB --baseurl="https://dl.rockylinux.org/pub/rocky/9/CRB/x86_64/os"

--- a/daisy/rocky/9/kickstart/rocky_linux_9_optimized_gcp_accelerator_570.cfg
+++ b/daisy/rocky/9/kickstart/rocky_linux_9_optimized_gcp_accelerator_570.cfg
@@ -4,7 +4,7 @@
 # Install in text mode.
 text --non-interactive
 url --url="https://depot.ciq.com/public/download/ciq-sigcloud-next-9/ciq-sigcloud-next-9.x86_64"
-repo --name=ciq-sigcloud-next-nonfree-8 --baseurl="https://depot.ciq.com/public/download/ciq-sigcloud-next-9/ciq-sigcloud-next-9-nonfree.x86_64"
+repo --name=ciq-sigcloud-next-nonfree-9 --baseurl="https://depot.ciq.com/public/download/ciq-sigcloud-next-9/ciq-sigcloud-next-9-nonfree.x86_64"
 repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os" --excludepkgs="kernel,kernel-core"
 repo --name=AppStream --baseurl="https://dl.rockylinux.org/pub/rocky/9/AppStream/x86_64/os"
 repo --name=CRB --baseurl="https://dl.rockylinux.org/pub/rocky/9/CRB/x86_64/os"

--- a/daisy/rocky/9/kickstart/rocky_linux_9_optimized_gcp_accelerator_570_arm64.cfg
+++ b/daisy/rocky/9/kickstart/rocky_linux_9_optimized_gcp_accelerator_570_arm64.cfg
@@ -4,7 +4,7 @@
 # Install in text mode.
 text --non-interactive
 url --url="https://depot.ciq.com/public/download/ciq-sigcloud-next-9/ciq-sigcloud-next-9.aarch64"
-repo --name=ciq-sigcloud-next-nonfree-8 --baseurl="https://depot.ciq.com/public/download/ciq-sigcloud-next-9/ciq-sigcloud-next-9-nonfree.aarch64"
+repo --name=ciq-sigcloud-next-nonfree-9 --baseurl="https://depot.ciq.com/public/download/ciq-sigcloud-next-9/ciq-sigcloud-next-9-nonfree.aarch64"
 repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/9/BaseOS/aarch64/os" --excludepkgs="kernel,kernel-core"
 repo --name=AppStream --baseurl="https://dl.rockylinux.org/pub/rocky/9/AppStream/aarch64/os"
 repo --name=CRB --baseurl="https://dl.rockylinux.org/pub/rocky/9/CRB/aarch64/os"

--- a/daisy/rocky/9/kickstart/rocky_linux_9_optimized_gcp_accelerator_580.cfg
+++ b/daisy/rocky/9/kickstart/rocky_linux_9_optimized_gcp_accelerator_580.cfg
@@ -4,7 +4,7 @@
 # Install in text mode.
 text --non-interactive
 url --url="https://depot.ciq.com/public/download/ciq-sigcloud-next-9/ciq-sigcloud-next-9.x86_64"
-repo --name=ciq-sigcloud-next-nonfree-8 --baseurl="https://depot.ciq.com/public/download/ciq-sigcloud-next-9/ciq-sigcloud-next-9-nonfree.x86_64"
+repo --name=ciq-sigcloud-next-nonfree-9 --baseurl="https://depot.ciq.com/public/download/ciq-sigcloud-next-9/ciq-sigcloud-next-9-nonfree.x86_64"
 repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os" --excludepkgs="kernel,kernel-core"
 repo --name=AppStream --baseurl="https://dl.rockylinux.org/pub/rocky/9/AppStream/x86_64/os"
 repo --name=CRB --baseurl="https://dl.rockylinux.org/pub/rocky/9/CRB/x86_64/os"

--- a/daisy/rocky/9/kickstart/rocky_linux_9_optimized_gcp_accelerator_580_arm64.cfg
+++ b/daisy/rocky/9/kickstart/rocky_linux_9_optimized_gcp_accelerator_580_arm64.cfg
@@ -4,7 +4,7 @@
 # Install in text mode.
 text --non-interactive
 url --url="https://depot.ciq.com/public/download/ciq-sigcloud-next-9/ciq-sigcloud-next-9.aarch64"
-repo --name=ciq-sigcloud-next-nonfree-8 --baseurl="https://depot.ciq.com/public/download/ciq-sigcloud-next-9/ciq-sigcloud-next-9-nonfree.aarch64"
+repo --name=ciq-sigcloud-next-nonfree-9 --baseurl="https://depot.ciq.com/public/download/ciq-sigcloud-next-9/ciq-sigcloud-next-9-nonfree.aarch64"
 repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/9/BaseOS/aarch64/os" --excludepkgs="kernel,kernel-core"
 repo --name=AppStream --baseurl="https://dl.rockylinux.org/pub/rocky/9/AppStream/aarch64/os"
 repo --name=CRB --baseurl="https://dl.rockylinux.org/pub/rocky/9/CRB/aarch64/os"

--- a/daisy/rocky/9/kickstart/rocky_linux_9_optimized_gcp_accelerator_arm64.cfg
+++ b/daisy/rocky/9/kickstart/rocky_linux_9_optimized_gcp_accelerator_arm64.cfg
@@ -4,7 +4,7 @@
 # Install in text mode.
 text --non-interactive
 url --url="https://depot.ciq.com/public/download/ciq-sigcloud-next-9/ciq-sigcloud-next-9.aarch64"
-repo --name=ciq-sigcloud-next-nonfree-8 --baseurl="https://depot.ciq.com/public/download/ciq-sigcloud-next-9/ciq-sigcloud-next-9-nonfree.aarch64"
+repo --name=ciq-sigcloud-next-nonfree-9 --baseurl="https://depot.ciq.com/public/download/ciq-sigcloud-next-9/ciq-sigcloud-next-9-nonfree.aarch64"
 repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/9/BaseOS/aarch64/os" --excludepkgs="kernel,kernel-core"
 repo --name=AppStream --baseurl="https://dl.rockylinux.org/pub/rocky/9/AppStream/aarch64/os"
 repo --name=CRB --baseurl="https://dl.rockylinux.org/pub/rocky/9/CRB/aarch64/os"


### PR DESCRIPTION
When we first built SCN 10, we used an ED25519 GPG signing key for the packages.  It turns out that this doesn't work in FIPS mode, so we have switched to an RSA 4096 GPG signing key.  To ensure that updates continue to work seamlessly for those who installed systems using the original key, we have transitioned to a new location for packages signed with the new key.

This commit updates the SCN image build process to use the new location.

This also fixes a minor repo naming issue (probably only relevant in the logs).