### PR TITLE
Add IDPF tag to ARM64 images

### DIFF
--- a/publish/rocky/10/rocky_linux_10_arm64.publish.json
+++ b/publish/rocky/10/rocky_linux_10_arm64.publish.json
@@ -30,7 +30,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC"]` -}}
+  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC", "IDPF"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/publish/rocky/10/rocky_linux_10_optimized_gcp_arm64.publish.json
+++ b/publish/rocky/10/rocky_linux_10_optimized_gcp_arm64.publish.json
@@ -30,7 +30,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC"]` -}}
+  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC", "IDPF"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/publish/rocky/8/rocky_linux_8_arm64.publish.json
+++ b/publish/rocky/8/rocky_linux_8_arm64.publish.json
@@ -30,7 +30,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC"]` -}}
+  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC", "IDPF"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/publish/rocky/8/rocky_linux_8_optimized_gcp_arm64.publish.json
+++ b/publish/rocky/8/rocky_linux_8_optimized_gcp_arm64.publish.json
@@ -30,7 +30,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC"]` -}}
+  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC", "IDPF"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/publish/rocky/9/rocky_linux_9_arm64.publish.json
+++ b/publish/rocky/9/rocky_linux_9_arm64.publish.json
@@ -30,7 +30,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC"]` -}}
+  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC", "IDPF"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/publish/rocky/9/rocky_linux_9_optimized_gcp_arm64.publish.json
+++ b/publish/rocky/9/rocky_linux_9_optimized_gcp_arm64.publish.json
@@ -30,7 +30,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC"]` -}}
+  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC", "IDPF"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {


### PR DESCRIPTION
The ARM64 images have the IDPF driver available, so tag them as supporting IDPF.  Note that the Accelerator images are already tagged as supporting IDPF.