### PR TITLE
Untag IDPF from Rocky 8 ARM64 images

### DIFF
--- a/publish/rocky/8/rocky_linux_8_arm64.publish.json
+++ b/publish/rocky/8/rocky_linux_8_arm64.publish.json
@@ -30,7 +30,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC", "IDPF"]` -}}
+  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/publish/rocky/8/rocky_linux_8_optimized_gcp_arm64.publish.json
+++ b/publish/rocky/8/rocky_linux_8_optimized_gcp_arm64.publish.json
@@ -30,7 +30,7 @@
   "ComputeEndpoint": {{$endpoint}},
   "DeleteAfter": {{$delete_after}},
   {{- end}}
-  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC", "IDPF"]` -}}
+  {{$guest_features := `["UEFI_COMPATIBLE", "GVNIC"]` -}}
   {{$time := trimPrefix .publish_version "v"}}
   "Images": [
     {

--- a/publish/rocky/8/rocky_linux_8_optimized_gcp_nvidia_570_arm64.publish.json
+++ b/publish/rocky/8/rocky_linux_8_optimized_gcp_nvidia_570_arm64.publish.json
@@ -45,7 +45,7 @@
       "Labels": {
         "public-image": "true"
       },
-      "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC", "IDPF"]
+      "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC"]
     }
   ]
 }

--- a/publish/rocky/8/rocky_linux_8_optimized_gcp_nvidia_580_arm64.publish.json
+++ b/publish/rocky/8/rocky_linux_8_optimized_gcp_nvidia_580_arm64.publish.json
@@ -45,7 +45,7 @@
       "Labels": {
         "public-image": "true"
       },
-      "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC", "IDPF"]
+      "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC"]
     }
   ]
 }

--- a/publish/rocky/8/rocky_linux_8_optimized_gcp_nvidia_latest_arm64.publish.json
+++ b/publish/rocky/8/rocky_linux_8_optimized_gcp_nvidia_latest_arm64.publish.json
@@ -45,7 +45,7 @@
       "Labels": {
         "public-image": "true"
       },
-      "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC", "IDPF"]
+      "GuestOsFeatures": ["UEFI_COMPATIBLE", "GVNIC"]
     }
   ]
 }


### PR DESCRIPTION
Due to a bug in grub, Rocky 8 images cannot be booted on C4A Metal instances, so let's prevent that by removing the IDPF tag from the Rocky 8 ARM64 images.