### PR TITLE
June updates

### DIFF
--- a/daisy/rocky/10/kickstart/rocky_linux_10.cfg
+++ b/daisy/rocky/10/kickstart/rocky_linux_10.cfg
@@ -206,6 +206,9 @@ dracut -f --kver="${kver}"
 
 # Fix selinux contexts on /etc/resolv.conf.
 restorecon /etc/resolv.conf
+
+# Relabel the OpenSSH binaries. (EL10 ships the OpenSSH 9.8+ split-process model).
+restorecon -R -v /usr/sbin/sshd /usr/libexec/openssh/
 %end
 
 # Cleanup.

--- a/daisy/rocky/10/kickstart/rocky_linux_10_arm64.cfg
+++ b/daisy/rocky/10/kickstart/rocky_linux_10_arm64.cfg
@@ -198,6 +198,9 @@ dracut -f --kver="${kver}"
 
 # Fix selinux contexts on /etc/resolv.conf.
 restorecon /etc/resolv.conf
+
+# Relabel the OpenSSH binaries. (EL10 ships the OpenSSH 9.8+ split-process model).
+restorecon -R -v /usr/sbin/sshd /usr/libexec/openssh/
 %end
 
 # Cleanup.

--- a/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp.cfg
+++ b/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp.cfg
@@ -4,7 +4,7 @@
 # Install in text mode.
 text --non-interactive
 url --url="https://depot.ciq.com/public/download/ciq-scn-10/ciq-scn-10.x86_64"
-repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/10/BaseOS/x86_64/os" --excludepkgs="kernel*"
+repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/10/BaseOS/x86_64/os" --excludepkgs="kernel*,shim*"
 repo --name=AppStream --baseurl="https://dl.rockylinux.org/pub/rocky/10/AppStream/x86_64/os"
 repo --name=CRB --baseurl="https://dl.rockylinux.org/pub/rocky/10/CRB/x86_64/os"
 poweroff
@@ -210,6 +210,9 @@ dracut -f --kver="${kver}"
 
 # Fix selinux contexts on /etc/resolv.conf.
 restorecon /etc/resolv.conf
+
+# Relabel the OpenSSH binaries. (EL10 ships the OpenSSH 9.8+ split-process model).
+restorecon -R -v /usr/sbin/sshd /usr/libexec/openssh/
 %end
 
 # Cleanup.

--- a/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp_accelerator.cfg
+++ b/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp_accelerator.cfg
@@ -5,7 +5,7 @@
 text --non-interactive
 url --url="https://depot.ciq.com/public/download/ciq-scn-10/ciq-scn-10.x86_64"
 repo --name=ciq-sigcloud-next-nonfree-10 --baseurl="https://depot.ciq.com/public/download/ciq-scn-10/ciq-scn-10-nonfree.x86_64"
-repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/10/BaseOS/x86_64/os" --excludepkgs="kernel*"
+repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/10/BaseOS/x86_64/os" --excludepkgs="kernel*,shim*"
 repo --name=AppStream --baseurl="https://dl.rockylinux.org/pub/rocky/10/AppStream/x86_64/os"
 repo --name=CRB --baseurl="https://dl.rockylinux.org/pub/rocky/10/CRB/x86_64/os"
 poweroff
@@ -216,6 +216,9 @@ dracut -f --kver="${kver}"
 
 # Fix selinux contexts on /etc/resolv.conf.
 restorecon /etc/resolv.conf
+
+# Relabel the OpenSSH binaries. (EL10 ships the OpenSSH 9.8+ split-process model).
+restorecon -R -v /usr/sbin/sshd /usr/libexec/openssh/
 %end
 
 # Cleanup.

--- a/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp_accelerator_580.cfg
+++ b/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp_accelerator_580.cfg
@@ -5,7 +5,7 @@
 text --non-interactive
 url --url="https://depot.ciq.com/public/download/ciq-scn-10/ciq-scn-10.x86_64"
 repo --name=ciq-sigcloud-next-nonfree-10 --baseurl="https://depot.ciq.com/public/download/ciq-scn-10/ciq-scn-10-nonfree.x86_64"
-repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/10/BaseOS/x86_64/os" --excludepkgs="kernel*"
+repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/10/BaseOS/x86_64/os" --excludepkgs="kernel*,shim*"
 repo --name=AppStream --baseurl="https://dl.rockylinux.org/pub/rocky/10/AppStream/x86_64/os"
 repo --name=CRB --baseurl="https://dl.rockylinux.org/pub/rocky/10/CRB/x86_64/os"
 poweroff
@@ -216,6 +216,9 @@ dracut -f --kver="${kver}"
 
 # Fix selinux contexts on /etc/resolv.conf.
 restorecon /etc/resolv.conf
+
+# Relabel the OpenSSH binaries. (EL10 ships the OpenSSH 9.8+ split-process model).
+restorecon -R -v /usr/sbin/sshd /usr/libexec/openssh/
 %end
 
 # Cleanup.

--- a/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp_accelerator_580_arm64.cfg
+++ b/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp_accelerator_580_arm64.cfg
@@ -5,7 +5,7 @@
 text --non-interactive
 url --url="https://depot.ciq.com/public/download/ciq-scn-10/ciq-scn-10.aarch64"
 repo --name=ciq-sigcloud-next-nonfree-10 --baseurl="https://depot.ciq.com/public/download/ciq-scn-10/ciq-scn-10-nonfree.aarch64"
-repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/10/BaseOS/aarch64/os" --excludepkgs="kernel*"
+repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/10/BaseOS/aarch64/os" --excludepkgs="kernel*,shim*"
 repo --name=AppStream --baseurl="https://dl.rockylinux.org/pub/rocky/10/AppStream/aarch64/os"
 repo --name=CRB --baseurl="https://dl.rockylinux.org/pub/rocky/10/CRB/aarch64/os"
 poweroff
@@ -216,6 +216,9 @@ dracut -f --kver="${kver}"
 
 # Fix selinux contexts on /etc/resolv.conf.
 restorecon /etc/resolv.conf
+
+# Relabel the OpenSSH binaries. (EL10 ships the OpenSSH 9.8+ split-process model).
+restorecon -R -v /usr/sbin/sshd /usr/libexec/openssh/
 %end
 
 # Cleanup.

--- a/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp_accelerator_arm64.cfg
+++ b/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp_accelerator_arm64.cfg
@@ -5,7 +5,7 @@
 text --non-interactive
 url --url="https://depot.ciq.com/public/download/ciq-scn-10/ciq-scn-10.aarch64"
 repo --name=ciq-sigcloud-next-nonfree-10 --baseurl="https://depot.ciq.com/public/download/ciq-scn-10/ciq-scn-10-nonfree.aarch64"
-repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/10/BaseOS/aarch64/os" --excludepkgs="kernel*"
+repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/10/BaseOS/aarch64/os" --excludepkgs="kernel*,shim*"
 repo --name=AppStream --baseurl="https://dl.rockylinux.org/pub/rocky/10/AppStream/aarch64/os"
 repo --name=CRB --baseurl="https://dl.rockylinux.org/pub/rocky/10/CRB/aarch64/os"
 poweroff
@@ -216,6 +216,9 @@ dracut -f --kver="${kver}"
 
 # Fix selinux contexts on /etc/resolv.conf.
 restorecon /etc/resolv.conf
+
+# Relabel the OpenSSH binaries. (EL10 ships the OpenSSH 9.8+ split-process model).
+restorecon -R -v /usr/sbin/sshd /usr/libexec/openssh/
 %end
 
 # Cleanup.

--- a/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp_arm64.cfg
+++ b/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp_arm64.cfg
@@ -4,7 +4,7 @@
 # Install in text mode.
 text --non-interactive
 url --url="https://depot.ciq.com/public/download/ciq-scn-10/ciq-scn-10.aarch64"
-repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/10/BaseOS/aarch64/os" --excludepkgs="kernel*"
+repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/10/BaseOS/aarch64/os" --excludepkgs="kernel*,shim*"
 repo --name=AppStream --baseurl="https://dl.rockylinux.org/pub/rocky/10/AppStream/aarch64/os"
 repo --name=CRB --baseurl="https://dl.rockylinux.org/pub/rocky/10/CRB/aarch64/os"
 poweroff
@@ -204,6 +204,9 @@ dracut -f --kver="${kver}"
 
 # Fix selinux contexts on /etc/resolv.conf.
 restorecon /etc/resolv.conf
+
+# Relabel the OpenSSH binaries. (EL10 ships the OpenSSH 9.8+ split-process model).
+restorecon -R -v /usr/sbin/sshd /usr/libexec/openssh/
 %end
 
 # Cleanup.

--- a/daisy/rocky/8/kickstart/rocky_linux_8_optimized_gcp.cfg
+++ b/daisy/rocky/8/kickstart/rocky_linux_8_optimized_gcp.cfg
@@ -4,7 +4,7 @@
 # Install in text mode.
 text --non-interactive
 url --url="https://depot.ciq.com/public/download/ciq-sigcloud-next-8/ciq-sigcloud-next-8.x86_64"
-repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/8/BaseOS/x86_64/os" --excludepkgs="kernel,kernel-core"
+repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/8/BaseOS/x86_64/os" --excludepkgs="kernel,kernel-core,shim*"
 repo --name=AppStream --baseurl="https://dl.rockylinux.org/pub/rocky/8/AppStream/x86_64/os"
 repo --name=PowerTools --baseurl="https://dl.rockylinux.org/pub/rocky/8/PowerTools/x86_64/os"
 poweroff
@@ -121,7 +121,7 @@ EOM
 
 # Be sure we don't get kernels from the BaseOS repo
 tee -a /etc/yum.repos.d/Rocky-BaseOS.repo << EOM
-exclude=kernel*
+exclude=kernel*,shim*
 EOM
 %end
 # Google Compute Engine kickstart config for Enterprise Linux 8.

--- a/daisy/rocky/8/kickstart/rocky_linux_8_optimized_gcp_accelerator.cfg
+++ b/daisy/rocky/8/kickstart/rocky_linux_8_optimized_gcp_accelerator.cfg
@@ -5,7 +5,7 @@
 text --non-interactive
 url --url="https://depot.ciq.com/public/download/ciq-sigcloud-next-8/ciq-sigcloud-next-8.x86_64"
 repo --name=ciq-sigcloud-next-nonfree-8 --baseurl="https://depot.ciq.com/public/download/ciq-sigcloud-next-8/ciq-sigcloud-next-8-nonfree.x86_64"
-repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/8/BaseOS/x86_64/os" --excludepkgs="kernel,kernel-core"
+repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/8/BaseOS/x86_64/os" --excludepkgs="kernel,kernel-core,shim*"
 repo --name=AppStream --baseurl="https://dl.rockylinux.org/pub/rocky/8/AppStream/x86_64/os"
 repo --name=PowerTools --baseurl="https://dl.rockylinux.org/pub/rocky/8/PowerTools/x86_64/os"
 poweroff
@@ -124,7 +124,7 @@ EOM
 
 # Be sure we don't get kernels from the BaseOS repo
 tee -a /etc/yum.repos.d/Rocky-BaseOS.repo << EOM
-exclude=kernel*
+exclude=kernel*,shim*
 EOM
 %end
 # Google Compute Engine kickstart config for Enterprise Linux 8.

--- a/daisy/rocky/8/kickstart/rocky_linux_8_optimized_gcp_accelerator_580.cfg
+++ b/daisy/rocky/8/kickstart/rocky_linux_8_optimized_gcp_accelerator_580.cfg
@@ -5,7 +5,7 @@
 text --non-interactive
 url --url="https://depot.ciq.com/public/download/ciq-sigcloud-next-8/ciq-sigcloud-next-8.x86_64"
 repo --name=ciq-sigcloud-next-nonfree-8 --baseurl="https://depot.ciq.com/public/download/ciq-sigcloud-next-8/ciq-sigcloud-next-8-nonfree.x86_64"
-repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/8/BaseOS/x86_64/os" --excludepkgs="kernel,kernel-core"
+repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/8/BaseOS/x86_64/os" --excludepkgs="kernel,kernel-core,shim*"
 repo --name=AppStream --baseurl="https://dl.rockylinux.org/pub/rocky/8/AppStream/x86_64/os"
 repo --name=PowerTools --baseurl="https://dl.rockylinux.org/pub/rocky/8/PowerTools/x86_64/os"
 poweroff
@@ -124,7 +124,7 @@ EOM
 
 # Be sure we don't get kernels from the BaseOS repo
 tee -a /etc/yum.repos.d/Rocky-BaseOS.repo << EOM
-exclude=kernel*
+exclude=kernel*,shim*
 EOM
 %end
 # Google Compute Engine kickstart config for Enterprise Linux 8.

--- a/daisy/rocky/8/kickstart/rocky_linux_8_optimized_gcp_accelerator_580_arm64.cfg
+++ b/daisy/rocky/8/kickstart/rocky_linux_8_optimized_gcp_accelerator_580_arm64.cfg
@@ -5,7 +5,7 @@
 text --non-interactive
 url --url="https://depot.ciq.com/public/download/ciq-sigcloud-next-8/ciq-sigcloud-next-8.aarch64"
 repo --name=ciq-sigcloud-next-nonfree-8 --baseurl="https://depot.ciq.com/public/download/ciq-sigcloud-next-8/ciq-sigcloud-next-8-nonfree.aarch64"
-repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/8/BaseOS/aarch64/os" --excludepkgs="kernel,kernel-core"
+repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/8/BaseOS/aarch64/os" --excludepkgs="kernel,kernel-core,shim*"
 repo --name=AppStream --baseurl="https://dl.rockylinux.org/pub/rocky/8/AppStream/aarch64/os"
 repo --name=PowerTools --baseurl="https://dl.rockylinux.org/pub/rocky/8/PowerTools/aarch64/os"
 poweroff
@@ -124,7 +124,7 @@ EOM
 
 # Be sure we don't get kernels from the BaseOS repo
 tee -a /etc/yum.repos.d/Rocky-BaseOS.repo << EOM
-exclude=kernel*
+exclude=kernel*,shim*
 EOM
 %end
 # Google Compute Engine kickstart config for Enterprise Linux 8.

--- a/daisy/rocky/8/kickstart/rocky_linux_8_optimized_gcp_accelerator_arm64.cfg
+++ b/daisy/rocky/8/kickstart/rocky_linux_8_optimized_gcp_accelerator_arm64.cfg
@@ -5,7 +5,7 @@
 text --non-interactive
 url --url="https://depot.ciq.com/public/download/ciq-sigcloud-next-8/ciq-sigcloud-next-8.aarch64"
 repo --name=ciq-sigcloud-next-nonfree-8 --baseurl="https://depot.ciq.com/public/download/ciq-sigcloud-next-8/ciq-sigcloud-next-8-nonfree.aarch64"
-repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/8/BaseOS/aarch64/os" --excludepkgs="kernel,kernel-core"
+repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/8/BaseOS/aarch64/os" --excludepkgs="kernel,kernel-core,shim*"
 repo --name=AppStream --baseurl="https://dl.rockylinux.org/pub/rocky/8/AppStream/aarch64/os"
 repo --name=PowerTools --baseurl="https://dl.rockylinux.org/pub/rocky/8/PowerTools/aarch64/os"
 poweroff
@@ -124,7 +124,7 @@ EOM
 
 # Be sure we don't get kernels from the BaseOS repo
 tee -a /etc/yum.repos.d/Rocky-BaseOS.repo << EOM
-exclude=kernel*
+exclude=kernel*,shim*
 EOM
 %end
 # Google Compute Engine kickstart config for Enterprise Linux 8.

--- a/daisy/rocky/8/kickstart/rocky_linux_8_optimized_gcp_arm64.cfg
+++ b/daisy/rocky/8/kickstart/rocky_linux_8_optimized_gcp_arm64.cfg
@@ -4,7 +4,7 @@
 # Install in text mode.
 text --non-interactive
 url --url="https://depot.ciq.com/public/download/ciq-sigcloud-next-8/ciq-sigcloud-next-8.aarch64"
-repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/8/BaseOS/aarch64/os" --excludepkgs="kernel, kernel-core"
+repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/8/BaseOS/aarch64/os" --excludepkgs="kernel, kernel-core, shim*"
 repo --name=AppStream --baseurl="https://dl.rockylinux.org/pub/rocky/8/AppStream/aarch64/os"
 repo --name=PowerTools --baseurl="https://dl.rockylinux.org/pub/rocky/8/PowerTools/aarch64/os"
 poweroff
@@ -121,7 +121,7 @@ EOM
 
 # Be sure we don't get kernels from the BaseOS repo
 tee -a /etc/yum.repos.d/Rocky-BaseOS.repo << EOM
-exclude=kernel*
+exclude=kernel*,shim*
 EOM
 %end
 # Google Compute Engine kickstart config for Enterprise Linux 8.

--- a/publish/rocky/10/rocky_linux_10_optimized_gcp_nvidia_latest.publish.json
+++ b/publish/rocky/10/rocky_linux_10_optimized_gcp_nvidia_latest.publish.json
@@ -35,7 +35,7 @@
     {
       "Prefix": "rocky-linux-10-optimized-gcp-nvidia-latest",
       "Family": "rocky-linux-10-optimized-gcp-nvidia-latest",
-      "Description": "Rocky Linux, Rocky Linux, 10 with the latest Nvidia driver (590), x86_64 optimized for GCP built on {{$time}}",
+      "Description": "Rocky Linux, Rocky Linux, 10 with the latest Nvidia driver (595), x86_64 optimized for GCP built on {{$time}}",
       "Architecture": "X86_64",
       "Licenses": [
         "projects/rocky-linux-accelerator-cloud/global/licenses/nvidia-latest",

--- a/publish/rocky/10/rocky_linux_10_optimized_gcp_nvidia_latest_arm64.publish.json
+++ b/publish/rocky/10/rocky_linux_10_optimized_gcp_nvidia_latest_arm64.publish.json
@@ -35,7 +35,7 @@
     {
       "Prefix": "rocky-linux-10-optimized-gcp-nvidia-latest-arm64",
       "Family": "rocky-linux-10-optimized-gcp-nvidia-latest-arm64",
-      "Description": "Rocky Linux, Rocky Linux, 10 with the latest Nvidia driver (590), aarch64 optimized for GCP built on {{$time}}",
+      "Description": "Rocky Linux, Rocky Linux, 10 with the latest Nvidia driver (595), aarch64 optimized for GCP built on {{$time}}",
       "Architecture": "ARM64",
       "Licenses": [
         "projects/rocky-linux-accelerator-cloud/global/licenses/nvidia-latest",

--- a/publish/rocky/8/rocky_linux_8_optimized_gcp_nvidia_latest.publish.json
+++ b/publish/rocky/8/rocky_linux_8_optimized_gcp_nvidia_latest.publish.json
@@ -35,7 +35,7 @@
     {
       "Prefix": "rocky-linux-8-optimized-gcp-nvidia-latest",
       "Family": "rocky-linux-8-optimized-gcp-nvidia-latest",
-      "Description": "Rocky Linux, Rocky Linux, 8 with the latest Nvidia driver (590), x86_64 optimized for GCP built on {{$time}}",
+      "Description": "Rocky Linux, Rocky Linux, 8 with the latest Nvidia driver (595), x86_64 optimized for GCP built on {{$time}}",
       "Architecture": "X86_64",
       "Licenses": [
         "https://www.googleapis.com/compute/v1/projects/rocky-linux-accelerator-cloud/global/licenses/nvidia-latest",

--- a/publish/rocky/8/rocky_linux_8_optimized_gcp_nvidia_latest_arm64.publish.json
+++ b/publish/rocky/8/rocky_linux_8_optimized_gcp_nvidia_latest_arm64.publish.json
@@ -35,7 +35,7 @@
     {
       "Prefix": "rocky-linux-8-optimized-gcp-nvidia-latest-arm64",
       "Family": "rocky-linux-8-optimized-gcp-nvidia-latest-arm64",
-      "Description": "Rocky Linux, Rocky Linux, 8 with the latest Nvidia driver (590), aarch64 optimized for GCP built on {{$time}}",
+      "Description": "Rocky Linux, Rocky Linux, 8 with the latest Nvidia driver (595), aarch64 optimized for GCP built on {{$time}}",
       "Architecture": "ARM64",
       "Licenses": [
         "https://www.googleapis.com/compute/v1/projects/rocky-linux-accelerator-cloud/global/licenses/nvidia-latest",

--- a/publish/rocky/9/rocky_linux_9_optimized_gcp_nvidia_latest.publish.json
+++ b/publish/rocky/9/rocky_linux_9_optimized_gcp_nvidia_latest.publish.json
@@ -35,7 +35,7 @@
     {
       "Prefix": "rocky-linux-9-optimized-gcp-nvidia-latest",
       "Family": "rocky-linux-9-optimized-gcp-nvidia-latest",
-      "Description": "Rocky Linux, Rocky Linux, 9 with the latest Nvidia driver (590), x86_64 optimized for GCP built on {{$time}}",
+      "Description": "Rocky Linux, Rocky Linux, 9 with the latest Nvidia driver (595), x86_64 optimized for GCP built on {{$time}}",
       "Architecture": "X86_64",
       "Licenses": [
         "https://www.googleapis.com/compute/v1/projects/rocky-linux-accelerator-cloud/global/licenses/nvidia-latest",

--- a/publish/rocky/9/rocky_linux_9_optimized_gcp_nvidia_latest_arm64.publish.json
+++ b/publish/rocky/9/rocky_linux_9_optimized_gcp_nvidia_latest_arm64.publish.json
@@ -35,7 +35,7 @@
     {
       "Prefix": "rocky-linux-9-optimized-gcp-nvidia-latest-arm64",
       "Family": "rocky-linux-9-optimized-gcp-nvidia-latest-arm64",
-      "Description": "Rocky Linux, Rocky Linux, 9 with the latest Nvidia driver (590), aarch64 optimized for GCP built on {{$time}}",
+      "Description": "Rocky Linux, Rocky Linux, 9 with the latest Nvidia driver (595), aarch64 optimized for GCP built on {{$time}}",
       "Architecture": "ARM64",
       "Licenses": [
         "https://www.googleapis.com/compute/v1/projects/rocky-linux-accelerator-cloud/global/licenses/nvidia-latest",


### PR DESCRIPTION
This change:
- bumps Nvidia latest to 595
- excludes shim packages from BaseOS to avoid package conflict with ciq shim
- add new `restorecon` command to fix SELinux labeling on openssh on RL 10