### PR TITLE
feat: add rocky-linux-10-optimized-gcp-oot-gve image

### DIFF
--- a/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp_oot_gve.cfg
+++ b/daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp_oot_gve.cfg
@@ -1,0 +1,295 @@
+# rocky-linux-10-optimized-gcp-oot-gve.cfg
+#
+# Rocky Linux 10 optimized for GCP (CIQ SIG Cloud "Next" / ciq-scn-10 kernel)
+# with the out-of-tree GVNIC (GVE) driver. This is the rocky-linux-10-optimized-gcp
+# build plus, mirroring Google's rhel-10-gvnic-baremetal image:
+#   1. the gve-el10-stable repo,
+#   2. EPEL (provides dkms, required to build the out-of-tree module),
+#   3. `dnf -y install gve` (a DKMS package built against the installed SCN kernel).
+
+### Anaconda installer configuration.
+# Install in text mode.
+text --non-interactive
+url --url="https://depot.ciq.com/public/download/ciq-scn-10/ciq-scn-10.x86_64"
+repo --name=BaseOS --baseurl="https://dl.rockylinux.org/pub/rocky/10/BaseOS/x86_64/os" --excludepkgs="kernel*,shim*"
+repo --name=AppStream --baseurl="https://dl.rockylinux.org/pub/rocky/10/AppStream/x86_64/os"
+repo --name=CRB --baseurl="https://dl.rockylinux.org/pub/rocky/10/CRB/x86_64/os"
+poweroff
+
+# Network configuration
+network --bootproto=dhcp --device=link
+
+### Installed system configuration.
+firewall --enabled
+services --enabled=sshd,rngd --disabled=sshd-keygen@
+skipx
+timezone --utc UTC
+timesource --ntp-server metadata.google.internal
+rootpw --iscrypted --lock *
+firstboot --disabled
+user --name=gce --lock
+
+### Disk configuration.
+# Disk configuration is done by including a separate file with disk configuration, otherwise anaconda will try to validate that the disk exists before we configure udev rules.
+%pre --erroronfail --log=/dev/ttyS0 --interpreter=/usr/bin/bash
+cp /run/install/isodir/65-gce-disk-naming.rules /etc/udev/rules.d/
+cp /run/install/isodir/google_nvme_id /usr/lib/udev/
+chmod +x /usr/lib/udev/google_nvme_id
+# Wait for coldplug events from boot to settle, or we won't generate new events for the reload/trigger
+udevadm settle
+udevadm control --reload
+udevadm trigger --settle
+tee -a /tmp/disk-config << EOM
+# build_installer.py will replace with the id of the install disk to avoid race conditions
+bootloader --boot-drive=/dev/disk/by-id/google-el-install-disk --timeout=0 --append="net.ifnames=0 biosdevname=0 scsi_mod.use_blk_mq=Y"
+# EFI partitioning, creates a GPT partitioned disk.
+clearpart --drives=/dev/disk/by-id/google-el-install-disk --all
+part /boot/efi --size=200 --fstype=efi --ondrive=/dev/disk/by-id/google-el-install-disk
+part / --size=100 --grow --ondrive=/dev/disk/by-id/google-el-install-disk --label=root --fstype=xfs
+EOM
+%end
+%include /tmp/disk-config
+
+# packages.cfg
+# Contains a list of packages to be installed, or not, on all flavors.
+# The %package command begins the package selection section of kickstart.
+# Packages can be specified by group, or package name. @Base and @Core are
+# always selected by default so they do not need to be specified.
+
+%packages
+acpid
+ciq-sigcloud-next-release
+dnf-automatic
+net-tools
+openssh-server
+python3
+rng-tools
+tar
+vim
+-subscription-manager
+-rhc
+-insights-client
+-alsa-utils
+-b43-fwcutter
+-dmraid
+-eject
+-gpm
+-irqbalance
+-microcode_ctl
+-smartmontools
+-aic94xx-firmware
+-atmel-firmware
+-b43-openfwwf
+-bfa-firmware
+-ipw2100-firmware
+-ipw2200-firmware
+-ivtv-firmware
+-iwl100-firmware
+-iwl1000-firmware
+-iwl3945-firmware
+-iwl4965-firmware
+-iwl5000-firmware
+-iwl5150-firmware
+-iwl6000-firmware
+-iwl6000g2a-firmware
+-iwl6050-firmware
+-kernel-firmware
+-libertas-usb8388-firmware
+-ql2100-firmware
+-ql2200-firmware
+-ql23xx-firmware
+-ql2400-firmware
+-ql2500-firmware
+-rt61pci-firmware
+-rt73usb-firmware
+-xorg-x11-drv-ati-firmware
+-zd1211-firmware
+%end
+
+%post --erroronfail --log=/dev/ttyS0
+set -ex
+tee -a /etc/yum.repos.d/google-cloud.repo << EOM
+[google-compute-engine]
+name=Google Compute Engine
+baseurl=https://packages.cloud.google.com/yum/repos/google-compute-engine-el10-x86-64-stable
+enabled=1
+gpgcheck=1
+repo_gpgcheck=0
+gpgkey=https://packages.cloud.google.com/yum/doc/rpm-package-key-v10.gpg
+EOM
+tee -a /etc/yum.repos.d/google-cloud.repo << EOM
+[google-cloud-sdk]
+name=Google Cloud SDK
+baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el10-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=0
+gpgkey=https://packages.cloud.google.com/yum/doc/rpm-package-key-v10.gpg
+EOM
+
+# Add the out-of-tree GVE (gVNIC) driver repo.
+# Mirrors Google's rhel-10-gvnic-baremetal build. Uses the same Google v10
+# signing key already referenced by the google-cloud repos above.
+tee -a /etc/yum.repos.d/gve.repo << EOM
+[gve-el10-stable]
+name=GVE Public Stable Repo
+baseurl=https://packages.cloud.google.com/yum/repos/gve-el10-stable
+enabled=1
+gpgcheck=1
+repo_gpgcheck=0
+gpgkey=https://packages.cloud.google.com/yum/doc/rpm-package-key-v10.gpg
+EOM
+
+# Be sure we don't get kernels from the BaseOS repo
+sed -i '/\[baseos\]/a exclude=kernel*' /etc/yum.repos.d/rocky.repo
+%end
+# Google Compute Engine kickstart config for Enterprise Linux 10.
+%onerror
+echo "Build Failed!" > /dev/ttyS0
+shutdown -h now
+%end
+
+%post --erroronfail --log=/dev/ttyS0
+set -ex
+# Delete the dummy user account.
+userdel -r gce
+
+# Import all RPM GPG keys.
+curl -o /etc/pki/rpm-gpg/rpm-package-key-v10.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key-v10.gpg
+rpm --import /etc/pki/rpm-gpg/*.gpg
+
+# Configure the network for GCE.
+# Given that GCE users typically control the firewall at the network API level,
+# we want to leave the standard Linux firewall setup enabled but all-open.
+firewall-offline-cmd --set-default-zone=trusted
+
+# Set google-compute-engine config for EL10.
+cat >>/etc/default/instance_configs.cfg.distro << EOL
+# Disable boto plugin setup.
+[InstanceSetup]
+set_boto_config = false
+EOL
+
+# Install GCE guest packages.
+# cloud-utils-growpart (growpart) is required by the gce-disk-expand dracut
+# module for root-disk auto-expansion. EL10 no longer ships gdisk/sgdisk;
+# growpart falls back to sfdisk (from util-linux, already present) — see the
+# dracut.conf.d handling before the initramfs regen below.
+dnf install -y google-compute-engine google-osconfig-agent gce-disk-expand cloud-utils-growpart
+rpm -q google-compute-engine google-osconfig-agent gce-disk-expand cloud-utils-growpart || { echo "Build Failed!" > /dev/ttyS0; exit 1; }
+
+# Install the Cloud SDK package.
+dnf install -y google-cloud-cli
+rpm -q google-cloud-cli || { echo "Build Failed!" > /dev/ttyS0; exit 1; }
+
+# Send /root/anaconda-ks.cfg to our logs.
+cp /run/install/ks.cfg /tmp/anaconda-ks.cfg
+
+# Remove files which shouldn't make it into the image. Its possible these files
+# will not exist.
+rm -f /etc/boto.cfg /etc/udev/rules.d/70-persistent-net.rules
+
+# Remove ens4 config from installer.
+rm -f /etc/sysconfig/network-scripts/ifcfg-ens4
+
+# Disable password authentication by default.
+sed -i -e '/#PasswordAuthentication/s/.*/PasswordAuthentication no/' /etc/ssh/sshd_config
+
+# Set ServerAliveInterval and ClientAliveInterval to prevent SSH
+# disconnections. The pattern match is tuned to each source config file.
+# The $'...' quoting syntax tells the shell to expand escape characters.
+sed -i -e $'/^\tServerAliveInterval/d' /etc/ssh/ssh_config
+sed -i -e $'/^Host \\*$/a \\\tServerAliveInterval 420' /etc/ssh/ssh_config
+sed -i -e '/ClientAliveInterval/s/^.*/ClientAliveInterval 420/' /etc/ssh/sshd_config
+
+# Disable root login via SSH by default.
+sed -i -e '/#PermitRootLogin/s/.*/PermitRootLogin no/' /etc/ssh/sshd_config
+
+# Update all packages.
+dnf -y update
+
+# Install the out-of-tree GVE (gVNIC) driver.
+# The gve package is a DKMS module (EPEL provides dkms); it is compiled here
+# against kernel-devel for the installed (post-update) SCN kernel. kernel-devel
+# is served by the ciq-scn-10 repo (the stock Rocky kernel* is excluded above).
+# Installed after `dnf -y update` so the module is built for the kernel the
+# image ships, and before the dracut regen below so it can be picked up in the
+# initramfs.
+dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
+rpm -q epel-release || { echo "Build Failed!" > /dev/ttyS0; exit 1; }
+
+# Build dependencies + kernel-devel matching the installed (latest) SCN kernel.
+gve_kver="$(rpm -q kernel --qf '%{VERSION}-%{RELEASE}.%{ARCH}\n' | sort -V | tail -n1)"
+dnf install -y dkms make gcc "kernel-devel-${gve_kver}"
+rpm -q "kernel-devel-${gve_kver}" || { echo "Build Failed!" > /dev/ttyS0; exit 1; }
+
+# Install the gve package. Its DKMS scriptlet auto-builds against the installer
+# environment's running kernel (uname -r), which is NOT the SCN kernel this image
+# ships, so that scriptlet build fails harmlessly here (POSTIN exit status 21).
+# We build for the target kernel explicitly below.
+dnf -y install gve
+rpm -q gve || { echo "Build Failed!" > /dev/ttyS0; exit 1; }
+
+# Build and install the out-of-tree module against the SCN kernel the image ships.
+gve_ver="$(rpm -q gve --qf '%{VERSION}\n')"
+dkms install -m gve -v "${gve_ver}" -k "${gve_kver}" --force
+
+# Verify the out-of-tree DKMS module is installed for the shipped kernel.
+# The SCN kernel also ships an in-tree gve, so a modinfo-only check would match
+# that and mask a failed OOT build; gate on DKMS status for the target kernel.
+dkms status -m gve -k "${gve_kver}"
+dkms status -m gve -k "${gve_kver}" | grep -q ': installed' || { echo "Build Failed! gve DKMS module not installed for ${gve_kver}" > /dev/ttyS0; exit 1; }
+
+# Log which gve the target kernel will actually load (should be the DKMS build,
+# from updates/ or extra/, taking precedence over the in-tree module).
+modinfo -k "${gve_kver}" -F filename -F version gve
+
+# Make changes to dnf automatic.conf
+# Apply updates for security (RHEL) by default. NOTE this will not work in CentOS.
+sed -i 's/upgrade_type =.*/upgrade_type = security/' /etc/dnf/automatic.conf
+sed -i 's/apply_updates =.*/apply_updates = yes/' /etc/dnf/automatic.conf
+# Enable the DNF automatic timer service.
+systemctl enable dnf-automatic.timer
+
+# Cleanup this repo- we don't want to continue updating with it.
+# Depending which repos are used in build, one or more of these files will not
+# exist.
+rm -f /etc/yum.repos.d/google-cloud-unstable.repo \
+  /etc/yum.repos.d/google-cloud-staging.repo
+
+# Clean up the cache for smaller images.
+dnf clean all
+rm -fr /var/cache/dnf/*
+
+# Blacklist the floppy module.
+echo "blacklist floppy" > /etc/modprobe.d/blacklist-floppy.conf
+restorecon /etc/modprobe.d/blacklist-floppy.conf
+
+# EL10 dropped gdisk/sgdisk. gce-disk-expand's dracut integration still requests
+# sgdisk for the initramfs; redirect any such request to sfdisk (from util-linux),
+# which growpart uses as its partition-resize backend when sgdisk is absent.
+# Covers both packaged files (rpm -ql) and %post-created drop-ins in conf.d.
+if ! command -v sgdisk >/dev/null 2>&1; then
+  for f in $(rpm -ql gce-disk-expand | grep dracut) /etc/dracut.conf.d/*.conf; do
+    if [ -f "$f" ] && grep -q sgdisk "$f"; then
+      sed -i 's/sgdisk/sfdisk/g' "$f"
+    fi
+  done
+fi
+
+# Generate initramfs from latest kernel instead of the running kernel.
+kver="$(ls -t /lib/modules | head -n1)"
+dracut -f --kver="${kver}"
+
+# Fix selinux contexts on /etc/resolv.conf.
+restorecon /etc/resolv.conf
+
+# Relabel the OpenSSH binaries. (EL10 ships the OpenSSH 9.8+ split-process model).
+restorecon -R -v /usr/sbin/sshd /usr/libexec/openssh/
+%end
+
+# Cleanup.
+%post --erroronfail --nochroot --log=/dev/ttyS0
+set -ex
+rm -Rf /mnt/sysimage/tmp/*
+%end

--- a/daisy/rocky/10/rocky_linux_10_optimized_gcp_oot_gve.wf.json
+++ b/daisy/rocky/10/rocky_linux_10_optimized_gcp_oot_gve.wf.json
@@ -1,0 +1,52 @@
+{
+  "Name": "build-rocky-linux-10-optimized-gcp-oot-gve",
+  "Vars": {
+    "installer_iso": {
+      "Required": true,
+      "Description": "The Rocky Linux 10 installer ISO to build from."
+    },
+    "build_date": {
+      "Value": "${TIMESTAMP}",
+      "Description": "Build datestamp used to version the image."
+    },
+    "publish_project": {
+      "Value": "${PROJECT}",
+      "Description": "A project to publish the resulting image to."
+    }
+  },
+  "Steps": {
+    "build-rocky": {
+      "Timeout": "60m",
+      "IncludeWorkflow": {
+        "Path": "./enterprise_linux.wf.json",
+        "Vars": {
+          "el_release": "rocky-linux-10-optimized-gcp",
+          "kickstart_config": "./kickstart/rocky_linux_10_optimized_gcp_oot_gve.cfg",
+          "installer_iso": "${installer_iso}"
+        }
+      }
+    },
+    "create-image": {
+      "CreateImages": [
+        {
+          "Name": "rocky-linux-10-optimized-gcp-oot-gve-v${build_date}",
+          "SourceDisk": "el-install-disk",
+          "Licenses": [
+            "projects/rocky-linux-cloud/global/licenses/rocky-linux-10-optimized-gcp",
+            "projects/rocky-linux-cloud/global/licenses/rocky-linux-10-optimized-gcp-oot-gve"
+          ],
+          "Description": "Rocky Linux, Rocky Linux, 10 optimized for GCP with out-of-tree GVNIC (GVE) Support, x86_64 with out-of-tree GVNIC (GVE) Support built on ${build_date}",
+          "Family": "rocky-linux-10-optimized-gcp-oot-gve",
+          "Project": "${publish_project}",
+          "NoCleanup": true,
+          "ExactName": true,
+          "Architecture": "X86_64",
+          "GuestOsFeatures": ["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "GVNIC", "IDPF", "SEV_CAPABLE", "SEV_SNP_CAPABLE", "SEV_LIVE_MIGRATABLE", "SEV_LIVE_MIGRATABLE_V2", "TDX_CAPABLE"]
+        }
+      ]
+    }
+  },
+  "Dependencies": {
+    "create-image": ["build-rocky"]
+  }
+}

--- a/publish/rocky/10/rocky_linux_10_optimized_gcp_oot_gve.publish.json
+++ b/publish/rocky/10/rocky_linux_10_optimized_gcp_oot_gve.publish.json
@@ -1,0 +1,52 @@
+{{/*
+  Template to publish Rocky 10 optimized-for-GCP images with the out-of-tree
+  GVNIC (GVE) driver.
+  By default this template publishes to the 'ciq-build-images' project; the
+  'environment' variable selects 'test' (gce-ciq-images) or 'prod'
+  (rocky-linux-cloud). DeleteAfter defaults to 60 days for non-prod; prod images
+  have no expiry.
+*/}}
+{
+  "Name": "rocky-linux-10-optimized-gcp-oot-gve",
+  {{$work_project := printf "%q" "ciq-build-images" -}}
+  {{$endpoint := `"https://www.googleapis.com/compute/alpha/projects/"` -}}
+  {{$delete_after := `"24h*30*2"` -}}
+  {{if eq .environment "test" -}}
+  "WorkProject": {{$work_project}},
+  "PublishProject": "gce-ciq-images",
+  "ComputeEndpoint": {{$endpoint}},
+  "DeleteAfter": {{$delete_after}},
+  {{- else if eq .environment "prod" -}}
+  "WorkProject": {{$work_project}},
+  "PublishProject": "rocky-linux-cloud",
+  "ComputeEndpoint": {{$endpoint}},
+  {{- else if eq .environment "autopush" -}}
+  "WorkProject": {{$work_project}},
+  "PublishProject": "artifact-releaser-autopush",
+  "ComputeEndpoint": {{$endpoint}},
+  "DeleteAfter": "3h",
+  {{- else -}}
+  "WorkProject": {{$work_project}},
+  "PublishProject": {{$work_project}},
+  "ComputeEndpoint": {{$endpoint}},
+  "DeleteAfter": {{$delete_after}},
+  {{- end}}
+  {{$guest_features := `["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "GVNIC", "IDPF", "SEV_CAPABLE", "SEV_SNP_CAPABLE", "SEV_LIVE_MIGRATABLE", "SEV_LIVE_MIGRATABLE_V2", "TDX_CAPABLE"]` -}}
+  {{$time := trimPrefix .publish_version "v"}}
+  "Images": [
+    {
+      "Family": "rocky-linux-10-optimized-gcp-oot-gve",
+      "Prefix": "rocky-linux-10-optimized-gcp-oot-gve",
+      "Description": "Rocky Linux, Rocky Linux, 10 optimized for GCP with out-of-tree GVNIC (GVE) Support, x86_64 with out-of-tree GVNIC (GVE) Support built on {{$time}}",
+      "Architecture": "X86_64",
+      "Licenses": [
+        "projects/rocky-linux-cloud/global/licenses/rocky-linux-10-optimized-gcp",
+        "projects/rocky-linux-cloud/global/licenses/rocky-linux-10-optimized-gcp-oot-gve"
+      ],
+      "Labels": {
+        "public-image": "true"
+      },
+      "GuestOsFeatures": {{$guest_features}}
+    }
+  ]
+}

--- a/publish/rocky/10/rocky_linux_10_optimized_gcp_oot_gve.wf.json
+++ b/publish/rocky/10/rocky_linux_10_optimized_gcp_oot_gve.wf.json
@@ -1,0 +1,74 @@
+{
+  "Name": "rocky-linux-10-optimized-gcp-oot-gve",
+  "Project": "ciq-build-images",
+  "Zone": "europe-west4-a",
+  "GCSPath": "gs://ciq-build-images-bucket/daisy/${USERNAME}",
+  "Vars": {
+    "build_date": {
+      "Value": "${TIMESTAMP}",
+      "Description": "Build datestamp used to version the image."
+    },
+    "google_cloud_repo": {
+      "Value": "stable",
+      "Description": "The Google Cloud Repo branch to use."
+    },
+    "workflow_root": {
+      "Value": "/workflows",
+      "Description": "Root of github workflows, defaults to /workflows in the container."
+    },
+    "gcs_url": {
+      "Value": "gs://gce-ciq-images-prod-artifacts/${NAME}-v${TIMESTAMP}.tar.gz",
+      "Description": "The GCS path that image raw file exported to."
+    },
+    "sbom_destination": {
+      "Value": "gs://gce-ciq-images-sboms/${NAME}-v${TIMESTAMP}.sbom.json",
+      "Description": "SBOM final export destination, copies in place by default"
+    },
+    "installer_iso": {
+      "Value": "gs://gce-ciq-images-base-isos/Rocky-10-x86_64-boot.iso",
+      "Description": "The Rocky Linux 10 installer ISO to build from."
+    },
+    "sbom_util_gcs_root": {
+      "Value": "gs://gce-ciq-images-base-isos/syft",
+      "Description": "The root gcs bucket for sbomutil, if using sbomutil to generate the SBOM."
+    },
+    "sha256_txt": {
+       "Value": "${OUTSPATH}/export-image-shasum.txt",
+       "Description": "The file where the sha256 sum is stored."
+    }
+  },
+  "Steps": {
+    "build": {
+      "TimeOut": "60m",
+      "IncludeWorkflow": {
+        "Path": "${workflow_root}/rocky/10/rocky_linux_10_optimized_gcp_oot_gve.wf.json",
+        "Vars": {
+          "build_date": "${build_date}",
+          "installer_iso": "${installer_iso}"
+        }
+      }
+    },
+    "export-image": {
+      "Timeout": "60m",
+      "IncludeWorkflow": {
+        "Path": "${workflow_root}/export/disk_export.wf.json",
+        "Vars": {
+          "destination": "${gcs_url}",
+          "sbom_destination": "${sbom_destination}",
+          "source_disk": "el-install-disk",
+          "sbom_util_gcs_root": "${sbom_util_gcs_root}",
+          "sha256_txt": "${sha256_txt}"
+        }
+      }
+    },
+    "cleanup-image": {
+      "DeleteResources": {
+        "Images": ["rocky-linux-10-optimized-gcp-oot-gve-v${build_date}"]
+      }
+    }
+  },
+  "Dependencies": {
+    "export-image": ["build"],
+    "cleanup-image": ["export-image"]
+  }
+}


### PR DESCRIPTION
Adds the Rocky Linux 10 optimized-for-GCP image with the out-of-tree GVE (gVNIC) driver.

## What
- New image family `rocky-linux-10-optimized-gcp-oot-gve` (x86_64), built on the CIQ SCN kernel.
- Installs the OOT `gve` driver via DKMS from the `gve-el10-stable` repo, compiled against the shipped kernel (mirrors Google's rhel-10-gvnic-baremetal approach).
- Carries a dedicated `rocky-linux-10-optimized-gcp-oot-gve` license alongside the base `rocky-linux-10-optimized-gcp` license.
- Publishes to test (`gce-ciq-images`) or prod (`rocky-linux-cloud`).

## Files
- `daisy/rocky/10/kickstart/rocky_linux_10_optimized_gcp_oot_gve.cfg`
- `daisy/rocky/10/rocky_linux_10_optimized_gcp_oot_gve.wf.json`
- `publish/rocky/10/rocky_linux_10_optimized_gcp_oot_gve.wf.json`
- `publish/rocky/10/rocky_linux_10_optimized_gcp_oot_gve.publish.json`

## Notes
- Includes the EL10 initramfs fix (EL10 dropped `gdisk`/`sgdisk`; installs `cloud-utils-growpart` and redirects `sgdisk`→`sfdisk`) so `gce-disk-expand` works.
- The `rocky-linux-10-optimized-gcp-oot-gve` GCP license resource already exists in `rocky-linux-cloud`.
- Not included here: the `build_all.sh` podman/docker auto-detection (separate automation change) — needed only if the delivery runner uses docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)